### PR TITLE
Add output file with details of touchstone, disease, modelling group and aggregation to file names

### DIFF
--- a/R/stochastic_process.R
+++ b/R/stochastic_process.R
@@ -201,7 +201,7 @@ stone_stochastic_process <- function(con, modelling_group, disease,
   elapsed <- Sys.time() - start
   lg$info("Processing for modelling_group: %s, disease: %s completed in %s",
           modelling_group, disease, human_readable_time(elapsed))
-  invisible()
+  paths
 }
 
 

--- a/scripts/run_stochastic_process.R
+++ b/scripts/run_stochastic_process.R
@@ -22,10 +22,10 @@ continue_on_error <- function(expr) {
 
 do_stochastics_2021 <- function(con, test_run) {
   in_path <- "Z:/File requests/latest/202110gavi/"
-  out_path <- "Z:/stochastic_2021_output_2/aggregated/"
-  pre_aggregation_path <- "Z:/stochastic_2021_output_2/pre-aggregate/"
-  log_file <- "Z:/stochastic_2021_output_2/log.txt"
-  output_files <- "Z:/stochastic_2021_output_2/output_files.csv"
+  out_path <- "Z:/stochastic_2021_output/aggregated/"
+  pre_aggregation_path <- "Z:/stochastic_2021_output/pre-aggregate/"
+  log_file <- "Z:/stochastic_2021_output/log.txt"
+  output_files <- "Z:/stochastic_2021_output/output_files.csv"
   files <- data.frame(
     touchstone = character(0),
     modelling_group = character(0),

--- a/scripts/run_stochastic_process.R
+++ b/scripts/run_stochastic_process.R
@@ -80,9 +80,9 @@ do_stochastics_2021 <- function(con, test_run) {
       is_cohort = c(FALSE, TRUE, FALSE, TRUE),
       is_under5 = c(TRUE, TRUE, FALSE, FALSE)
     )
+    write.table(files, output_files, sep = ",", append = TRUE,
+                row.names = FALSE, col.names = FALSE)
   })
-  write.table(files, output_files, sep = ",", append = TRUE,
-              row.names = FALSE, col.names = FALSE)
 
   #############################################################################
 
@@ -90,37 +90,40 @@ do_stochastics_2021 <- function(con, test_run) {
   modelling_group = "Emory-Lopman"
   disease = "Rota"
   touchstone = "202110gavi-3"
-  continue_on_error(paths <- stone_stochastic_process(
-    con,
-    modelling_group = modelling_group,
-    disease = disease,
-    touchstone = touchstone,
-    scenarios = c("rota-no-vaccination",
-                  "rota-routine-default",
-                  "rota-routine-ia2030_target"),
-    in_path = file.path(in_path, "Emory-Lopman"),
-    files = c(paste0(stub, "no_vaccination_2022_01_31.csv.xz"),
-              paste0(stub, "routine_2022_01_31.csv.xz"),
-              paste0(stub, "ia2030_target_2022_01_31.csv.xz")),
-    cert = "",
-    index_start = NA,
-    index_end = NA,
-    out_path = out_path,
-    pre_aggregation_path = pre_aggregation_path,
-    log_file = log_file,
-    allow_missing_disease = TRUE,
-    bypass_cert_check = TRUE,
-    lines = lines))
-  files <- data.frame(
-    touchstone = touchstone,
-    modelling_group = modelling_group,
-    disease = disease,
-    files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
-              paths$all_cal_file, paths$all_coh_file),
-    is_cohort = c(FALSE, TRUE, FALSE, TRUE),
-    is_under5 = c(TRUE, TRUE, FALSE, FALSE)
-  )
-  write.csv(files, output_files, append = TRUE, row.names = FALSE)
+  continue_on_error({
+    paths <- stone_stochastic_process(
+      con,
+      modelling_group = modelling_group,
+      disease = disease,
+      touchstone = touchstone,
+      scenarios = c("rota-no-vaccination",
+                    "rota-routine-default",
+                    "rota-routine-ia2030_target"),
+      in_path = file.path(in_path, "Emory-Lopman"),
+      files = c(paste0(stub, "no_vaccination_2022_01_31.csv.xz"),
+                paste0(stub, "routine_2022_01_31.csv.xz"),
+                paste0(stub, "ia2030_target_2022_01_31.csv.xz")),
+      cert = "",
+      index_start = NA,
+      index_end = NA,
+      out_path = out_path,
+      pre_aggregation_path = pre_aggregation_path,
+      log_file = log_file,
+      allow_missing_disease = TRUE,
+      bypass_cert_check = TRUE,
+      lines = lines)
+    files <- data.frame(
+      touchstone = touchstone,
+      modelling_group = modelling_group,
+      disease = disease,
+      files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
+                paths$all_cal_file, paths$all_coh_file),
+      is_cohort = c(FALSE, TRUE, FALSE, TRUE),
+      is_under5 = c(TRUE, TRUE, FALSE, FALSE)
+    )
+    write.table(files, output_files, sep = ",", append = TRUE,
+                row.names = FALSE, col.names = FALSE)
+  })
 
   #############################################################################
 
@@ -128,116 +131,125 @@ do_stochastics_2021 <- function(con, test_run) {
   modelling_group = "Harvard-Sweet"
   disease = "HPV"
   touchstone = "202110gavi-3"
-  continue_on_error(paths <- stone_stochastic_process(
-    con,
-    modelling_group = modelling_group,
-    disease = disease,
-    touchstone = touchstone,
-    scenarios = c("hpv-no-vaccination",
-                  "hpv-campaign-default",
-                  "hpv-campaign-ia2030_target",
-                  "hpv-routine-default",
-                  "hpv-routine-ia2030_target"),
-    in_path = file.path(in_path, "Harvard-Sweet"),
-    files = c(paste0(stub, "novacc_run_:index.csv.xz"),
-              paste0(stub, "coverage_202110gavi-3_hpv-campaign-default_run_:index.csv.xz"),
-              paste0(stub, "coverage_202110gavi-3_hpv-campaign-ia2030_target_run_:index.csv.xz"),
-              paste0(stub, "coverage_202110gavi-3_hpv-routine-default_run_:index.csv.xz"),
-              paste0(stub, "coverage_202110gavi-3_hpv-routine-ia2030_target_run_:index.csv.xz")),
-    cert = "",
-    index_start = 1,
-    index_end = 200,
-    out_path = out_path,
-    pre_aggregation_path = pre_aggregation_path,
-    log_file = log_file,
-    runid_from_file = TRUE,
-    bypass_cert_check = TRUE,
-    lines = lines))
-  files <- data.frame(
-    touchstone = touchstone,
-    modelling_group = modelling_group,
-    disease = disease,
-    files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
-              paths$all_cal_file, paths$all_coh_file),
-    is_cohort = c(FALSE, TRUE, FALSE, TRUE),
-    is_under5 = c(TRUE, TRUE, FALSE, FALSE)
-  )
-  write.csv(files, output_files, append = TRUE, row.names = FALSE)
+  continue_on_error({
+    paths <- stone_stochastic_process(
+      con,
+      modelling_group = modelling_group,
+      disease = disease,
+      touchstone = touchstone,
+      scenarios = c("hpv-no-vaccination",
+                    "hpv-campaign-default",
+                    "hpv-campaign-ia2030_target",
+                    "hpv-routine-default",
+                    "hpv-routine-ia2030_target"),
+      in_path = file.path(in_path, "Harvard-Sweet"),
+      files = c(paste0(stub, "novacc_run_:index.csv.xz"),
+                paste0(stub, "coverage_202110gavi-3_hpv-campaign-default_run_:index.csv.xz"),
+                paste0(stub, "coverage_202110gavi-3_hpv-campaign-ia2030_target_run_:index.csv.xz"),
+                paste0(stub, "coverage_202110gavi-3_hpv-routine-default_run_:index.csv.xz"),
+                paste0(stub, "coverage_202110gavi-3_hpv-routine-ia2030_target_run_:index.csv.xz")),
+      cert = "",
+      index_start = 1,
+      index_end = 200,
+      out_path = out_path,
+      pre_aggregation_path = pre_aggregation_path,
+      log_file = log_file,
+      runid_from_file = TRUE,
+      bypass_cert_check = TRUE,
+      lines = lines)
+    files <- data.frame(
+      touchstone = touchstone,
+      modelling_group = modelling_group,
+      disease = disease,
+      files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
+                paths$all_cal_file, paths$all_coh_file),
+      is_cohort = c(FALSE, TRUE, FALSE, TRUE),
+      is_under5 = c(TRUE, TRUE, FALSE, FALSE)
+    )
+    write.table(files, output_files, sep = ",", append = TRUE,
+                row.names = FALSE, col.names = FALSE)
+  })
 
-   #############################################################################
+  #############################################################################
 
   stub <- "Keith Fraser - stochastic-burden-estimates.202110gavi-3_YF_IC-Garske_"
   modelling_group = "IC-Garske"
   disease = "YF"
   touchstone = "202110gavi-3"
-  continue_on_error(paths <- stone_stochastic_process(
-    con,
-    modelling_group = modelling_group,
-    disease = disease,
-    touchstone = touchstone,
-    scenarios = c("yf-no-vaccination",
-                  "yf-preventive-default",
-                  "yf-preventive-ia2030_target",
-                  "yf-routine-default",
-                  "yf-routine-ia2030_target"),
-    in_path = file.path(in_path, "IC-Garske"),
-    files = paste0(stub, ":scenario_:index.csv.xz"),
-    cert = "",
-    index_start = 1,
-    index_end = 200,
-    out_path = out_path,
-    pre_aggregation_path = pre_aggregation_path,
-    log_file = log_file,
-    bypass_cert_check = TRUE,
-    lines = lines))
-  files <- data.frame(
-    touchstone = touchstone,
-    modelling_group = modelling_group,
-    disease = disease,
-    files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
-              paths$all_cal_file, paths$all_coh_file),
-    is_cohort = c(FALSE, TRUE, FALSE, TRUE),
-    is_under5 = c(TRUE, TRUE, FALSE, FALSE)
-  )
-  write.csv(files, output_files, append = TRUE, row.names = FALSE)
+  continue_on_error({
+    paths <- stone_stochastic_process(
+      con,
+      modelling_group = modelling_group,
+      disease = disease,
+      touchstone = touchstone,
+      scenarios = c("yf-no-vaccination",
+                    "yf-preventive-default",
+                    "yf-preventive-ia2030_target",
+                    "yf-routine-default",
+                    "yf-routine-ia2030_target"),
+      in_path = file.path(in_path, "IC-Garske"),
+      files = paste0(stub, ":scenario_:index.csv.xz"),
+      cert = "",
+      index_start = 1,
+      index_end = 200,
+      out_path = out_path,
+      pre_aggregation_path = pre_aggregation_path,
+      log_file = log_file,
+      bypass_cert_check = TRUE,
+      lines = lines)
+    files <- data.frame(
+      touchstone = touchstone,
+      modelling_group = modelling_group,
+      disease = disease,
+      files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
+                paths$all_cal_file, paths$all_coh_file),
+      is_cohort = c(FALSE, TRUE, FALSE, TRUE),
+      is_under5 = c(TRUE, TRUE, FALSE, FALSE)
+    )
+    write.table(files, output_files, sep = ",", append = TRUE,
+                row.names = FALSE, col.names = FALSE)
+  })
 
   #############################################################################
 
   modelling_group = "IVI-Kim"
   disease = "Typhoid"
   touchstone = "202110gavi-3"
-  continue_on_error(paths <- stone_stochastic_process(
-    con,
-    modelling_group = modelling_group,
-    disease = disease,
-    touchstone = touchstone,
-    scenarios = c("typhoid-no-vaccination",
-                  "typhoid-campaign-default", "typhoid-campaign-ia2030_target",
-                  "typhoid-routine-default",  "typhoid-routine-ia2030_target"),
-    in_path = file.path(in_path, "IVI-Kim-Typhoid"),
-    files = c("Jong-Hoon Kim - stoch_Typhoid_novacc_20211217T1.csv.xz",
-              "Jong-Hoon Kim - stoch_Typhoid_campaign-default_20211217T1.csv.xz",
-              "Jong-Hoon Kim - stoch_Typhoid_campaign-ia2030_20211217T1.csv.xz",
-              "Jong-Hoon Kim - stoch_Typhoid_routine-default_20211217T1.csv.xz",
-              "Jong-Hoon Kim - stoch_Typhoid_routine-ia2030_20211217T1.csv.xz"),
-    cert = "",
-    index_start = NA,
-    index_end = NA,
-    out_path = out_path,
-    pre_aggregation_path = pre_aggregation_path,
-    log_file = log_file,
-    bypass_cert_check = TRUE,
-    lines = lines))
-  files <- data.frame(
-    touchstone = touchstone,
-    modelling_group = modelling_group,
-    disease = disease,
-    files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
-              paths$all_cal_file, paths$all_coh_file),
-    is_cohort = c(FALSE, TRUE, FALSE, TRUE),
-    is_under5 = c(TRUE, TRUE, FALSE, FALSE)
-  )
-  write.csv(files, output_files, append = TRUE, row.names = FALSE)
+  continue_on_error({
+    paths <- stone_stochastic_process(
+      con,
+      modelling_group = modelling_group,
+      disease = disease,
+      touchstone = touchstone,
+      scenarios = c("typhoid-no-vaccination",
+                    "typhoid-campaign-default", "typhoid-campaign-ia2030_target",
+                    "typhoid-routine-default",  "typhoid-routine-ia2030_target"),
+      in_path = file.path(in_path, "IVI-Kim-Typhoid"),
+      files = c("Jong-Hoon Kim - stoch_Typhoid_novacc_20211217T1.csv.xz",
+                "Jong-Hoon Kim - stoch_Typhoid_campaign-default_20211217T1.csv.xz",
+                "Jong-Hoon Kim - stoch_Typhoid_campaign-ia2030_20211217T1.csv.xz",
+                "Jong-Hoon Kim - stoch_Typhoid_routine-default_20211217T1.csv.xz",
+                "Jong-Hoon Kim - stoch_Typhoid_routine-ia2030_20211217T1.csv.xz"),
+      cert = "",
+      index_start = NA,
+      index_end = NA,
+      out_path = out_path,
+      pre_aggregation_path = pre_aggregation_path,
+      log_file = log_file,
+      bypass_cert_check = TRUE,
+      lines = lines)
+    files <- data.frame(
+      touchstone = touchstone,
+      modelling_group = modelling_group,
+      disease = disease,
+      files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
+                paths$all_cal_file, paths$all_coh_file),
+      is_cohort = c(FALSE, TRUE, FALSE, TRUE),
+      is_under5 = c(TRUE, TRUE, FALSE, FALSE)
+    )
+    write.table(files, output_files, sep = ",", append = TRUE,
+                row.names = FALSE, col.names = FALSE)
+  })
 
   #####################################################
 
@@ -245,107 +257,116 @@ do_stochastics_2021 <- function(con, test_run) {
   modelling_group = "IC-Hallett"
   disease = "HepB"
   touchstone = "202110gavi-3"
-  continue_on_error(paths <- stone_stochastic_process(
-    con,
-    modelling_group = modelling_group,
-    disease = disease,
-    touchstone = touchstone,
-    scenarios = c("hepb-bd-default-hepb-routine-default",
-                  "hepb-bd-routine-default",
-                  "hepb-bd-routine-ia2030_target-hepb-routine-ia2030_target",
-                  "hepb-bd-routine-ia2030_target",
-                  "hepb-hepb-routine-default",
-                  "hepb-hepb-routine-ia2030_target",
-                  "hepb-no-vaccination"),
-    in_path = file.path(in_path, "IC-Hallett"),
-    files = paste0(stub, ":scenario_:index.csv.xz"),
-    cert = "Margaret de Villiers - cert115",
-    index_start = 1,
-    index_end = 200,
-    out_path = out_path,
-    pre_aggregation_path = pre_aggregation_path,
-    log_file = log_file,
-    deaths = "deaths",
-    cases = c("hepb_cases_acute_severe","hepb_cases_comp_cirrh",
-              "hepb_cases_hcc_no_cirrh"),
-    dalys = "dalys",
-    lines = lines))
-  files <- data.frame(
-    touchstone = touchstone,
-    modelling_group = modelling_group,
-    disease = disease,
-    files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
-              paths$all_cal_file, paths$all_coh_file),
-    is_cohort = c(FALSE, TRUE, FALSE, TRUE),
-    is_under5 = c(TRUE, TRUE, FALSE, FALSE)
-  )
-  write.csv(files, output_files, append = TRUE, row.names = FALSE)
+  continue_on_error({
+    paths <- stone_stochastic_process(
+      con,
+      modelling_group = modelling_group,
+      disease = disease,
+      touchstone = touchstone,
+      scenarios = c("hepb-bd-default-hepb-routine-default",
+                    "hepb-bd-routine-default",
+                    "hepb-bd-routine-ia2030_target-hepb-routine-ia2030_target",
+                    "hepb-bd-routine-ia2030_target",
+                    "hepb-hepb-routine-default",
+                    "hepb-hepb-routine-ia2030_target",
+                    "hepb-no-vaccination"),
+      in_path = file.path(in_path, "IC-Hallett"),
+      files = paste0(stub, ":scenario_:index.csv.xz"),
+      cert = "Margaret de Villiers - cert115",
+      index_start = 1,
+      index_end = 200,
+      out_path = out_path,
+      pre_aggregation_path = pre_aggregation_path,
+      log_file = log_file,
+      deaths = "deaths",
+      cases = c("hepb_cases_acute_severe","hepb_cases_comp_cirrh",
+                "hepb_cases_hcc_no_cirrh"),
+      dalys = "dalys",
+      lines = lines)
+    files <- data.frame(
+      touchstone = touchstone,
+      modelling_group = modelling_group,
+      disease = disease,
+      files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
+                paths$all_cal_file, paths$all_coh_file),
+      is_cohort = c(FALSE, TRUE, FALSE, TRUE),
+      is_under5 = c(TRUE, TRUE, FALSE, FALSE)
+    )
+    write.table(files, output_files, sep = ",", append = TRUE,
+                row.names = FALSE, col.names = FALSE)
+  })
 
   #############################################################################
 
   modelling_group = "IVI-Kim"
   disease = "Cholera"
   touchstone = "202110gavi-3"
-  continue_on_error(paths <- stone_stochastic_process(
-    con,
-    modelling_group = modelling_group,
-    disease = disease,
-    touchstone = touchstone,
-    scenarios = c("cholera-no-vaccination", "cholera-campaign-default"),
-    in_path = file.path(in_path, "IVI-Kim-Cholera"),
-    files = c("Jong-Hoon Kim - stoch_Cholera_novacc_20211221T00.csv.xz",
-              "Jong-Hoon Kim - stoch_Cholera_campaign_20211222T212131.csv.xz"),
-    cert = "",
-    index_start = NA,
-    index_end = NA,
-    out_path = out_path,
-    pre_aggregation_path = pre_aggregation_path,
-    log_file = log_file,
-    bypass_cert_check = TRUE,
-    lines = lines))
-  files <- data.frame(
-    touchstone = touchstone,
-    modelling_group = modelling_group,
-    disease = disease,
-    files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
-              paths$all_cal_file, paths$all_coh_file),
-    is_cohort = c(FALSE, TRUE, FALSE, TRUE),
-    is_under5 = c(TRUE, TRUE, FALSE, FALSE)
-  )
-  write.csv(files, output_files, append = TRUE, row.names = FALSE)
+  continue_on_error({
+    paths <- stone_stochastic_process(
+      con,
+      modelling_group = modelling_group,
+      disease = disease,
+      touchstone = touchstone,
+      scenarios = c("cholera-no-vaccination", "cholera-campaign-default"),
+      in_path = file.path(in_path, "IVI-Kim-Cholera"),
+      files = c("Jong-Hoon Kim - stoch_Cholera_novacc_20211221T00.csv.xz",
+                "Jong-Hoon Kim - stoch_Cholera_campaign_20211222T212131.csv.xz"),
+      cert = "",
+      index_start = NA,
+      index_end = NA,
+      out_path = out_path,
+      pre_aggregation_path = pre_aggregation_path,
+      log_file = log_file,
+      bypass_cert_check = TRUE,
+      lines = lines)
+    files <- data.frame(
+      touchstone = touchstone,
+      modelling_group = modelling_group,
+      disease = disease,
+      files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
+                paths$all_cal_file, paths$all_coh_file),
+      is_cohort = c(FALSE, TRUE, FALSE, TRUE),
+      is_under5 = c(TRUE, TRUE, FALSE, FALSE)
+    )
+    write.table(files, output_files, sep = ",", append = TRUE,
+                row.names = FALSE, col.names = FALSE)
+  })
 
   #############################################################################
 
   modelling_group = "JHU-Lee"
   disease = "Cholera"
   touchstone = "202110gavi-3"
-  continue_on_error(paths <- stone_stochastic_process(
-    con,
-    modelling_group = modelling_group,
-    disease = disease,
-    touchstone = touchstone,
-    scenarios = c("cholera-no-vaccination", "cholera-campaign-default"),
-    in_path = file.path(in_path, "JHU-Lee-Cholera"),
-    files = c("Kaiyue Zou - no-vaccination.csv.xz",
-              "Kaiyue Zou - campaign-default.csv.xz"),
-    cert = "",
-    index_start = NA,
-    index_end = NA,
-    out_path = out_path,
-    pre_aggregation_path = pre_aggregation_path,
-    log_file = log_file,
-    bypass_cert_check = TRUE,
-    lines = lines))
-  files <- data.frame(
-    touchstone = touchstone,
-    modelling_group = modelling_group,
-    disease = disease,
-    files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
-              paths$all_cal_file, paths$all_coh_file),
-    is_cohort = c(FALSE, TRUE, FALSE, TRUE),
-    is_under5 = c(TRUE, TRUE, FALSE, FALSE)
-  )
-  write.csv(files, output_files, append = TRUE, row.names = FALSE)
+  continue_on_error({
+    paths <- stone_stochastic_process(
+      con,
+      modelling_group = modelling_group,
+      disease = disease,
+      touchstone = touchstone,
+      scenarios = c("cholera-no-vaccination", "cholera-campaign-default"),
+      in_path = file.path(in_path, "JHU-Lee-Cholera"),
+      files = c("Kaiyue Zou - no-vaccination.csv.xz",
+                "Kaiyue Zou - campaign-default.csv.xz"),
+      cert = "",
+      index_start = NA,
+      index_end = NA,
+      out_path = out_path,
+      pre_aggregation_path = pre_aggregation_path,
+      log_file = log_file,
+      bypass_cert_check = TRUE,
+      lines = lines)
+    files <- data.frame(
+      touchstone = touchstone,
+      modelling_group = modelling_group,
+      disease = disease,
+      files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
+                paths$all_cal_file, paths$all_coh_file),
+      is_cohort = c(FALSE, TRUE, FALSE, TRUE),
+      is_under5 = c(TRUE, TRUE, FALSE, FALSE)
+    )
+    write.table(files, output_files, sep = ",", append = TRUE,
+                row.names = FALSE, col.names = FALSE)
+  })
 
   #############################################################################
 
@@ -354,51 +375,54 @@ do_stochastics_2021 <- function(con, test_run) {
   modelling_group = "JHU-Lessler"
   disease = "Rubella"
   touchstone = "202110gavi-3"
-  continue_on_error(paths <- stone_stochastic_process(
-    con,
-    modelling_group = modelling_group,
-    disease = disease,
-    touchstone = touchstone,
-    scenarios = c("rubella-routine-no-vaccination",
-                  "rubella-campaign-default",
-                  "rubella-rcv1-default",
-                  "rubella-rcv2-default",
-                  "rubella-rcv1-rcv2-default",
-                  "rubella-campaign-ia2030_target",
-                  "rubella-rcv1-ia2030_target",
-                  "rubella-rcv2-ia2030_target",
-                  "rubella-rcv1-rcv2-ia2030_target"),
-    in_path = file.path(in_path, "JHU-UGA-Winter-Rubella"),
-    files = c(paste0(stub, "routine-no-vaccination_:index.csv.xz"),
-              paste0(stub, "campaign-default_:index.csv.xz"),
-              paste0(stub, "rcv1-default_:index.csv.xz"),
-              paste0(stub, "rcv2-default_:index.csv.xz"),
-              paste0(stub, "rcv1-rcv2-default_:index.csv.xz"),
-              paste0(stub, "campaign-ia2030_target_:index.csv.xz"),
-              paste0(stub, "rcv1-ia2030_target_:index.csv.xz"),
-              paste0(stub, "rcv2-ia2030_target_:index.csv.xz"),
-              paste0(stub, "rcv1-rcv2-ia2030_target_:index.csv.xz")),
-    cert = "",
-    index_start = 1,
-    index_end = 11,
-    out_path = out_path,
-    pre_aggregation_path = pre_aggregation_path,
-    log_file = log_file,
-    deaths = "rubella_deaths_congenital",
-    cases = "rubella_cases_congenital",
-    dalys = "dalys",
-    bypass_cert_check = TRUE,
-    lines = lines))
-  files <- data.frame(
-    touchstone = touchstone,
-    modelling_group = modelling_group,
-    disease = disease,
-    files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
-              paths$all_cal_file, paths$all_coh_file),
-    is_cohort = c(FALSE, TRUE, FALSE, TRUE),
-    is_under5 = c(TRUE, TRUE, FALSE, FALSE)
-  )
-  write.csv(files, output_files, append = TRUE, row.names = FALSE)
+  continue_on_error({
+    paths <- stone_stochastic_process(
+      con,
+      modelling_group = modelling_group,
+      disease = disease,
+      touchstone = touchstone,
+      scenarios = c("rubella-routine-no-vaccination",
+                    "rubella-campaign-default",
+                    "rubella-rcv1-default",
+                    "rubella-rcv2-default",
+                    "rubella-rcv1-rcv2-default",
+                    "rubella-campaign-ia2030_target",
+                    "rubella-rcv1-ia2030_target",
+                    "rubella-rcv2-ia2030_target",
+                    "rubella-rcv1-rcv2-ia2030_target"),
+      in_path = file.path(in_path, "JHU-UGA-Winter-Rubella"),
+      files = c(paste0(stub, "routine-no-vaccination_:index.csv.xz"),
+                paste0(stub, "campaign-default_:index.csv.xz"),
+                paste0(stub, "rcv1-default_:index.csv.xz"),
+                paste0(stub, "rcv2-default_:index.csv.xz"),
+                paste0(stub, "rcv1-rcv2-default_:index.csv.xz"),
+                paste0(stub, "campaign-ia2030_target_:index.csv.xz"),
+                paste0(stub, "rcv1-ia2030_target_:index.csv.xz"),
+                paste0(stub, "rcv2-ia2030_target_:index.csv.xz"),
+                paste0(stub, "rcv1-rcv2-ia2030_target_:index.csv.xz")),
+      cert = "",
+      index_start = 1,
+      index_end = 11,
+      out_path = out_path,
+      pre_aggregation_path = pre_aggregation_path,
+      log_file = log_file,
+      deaths = "rubella_deaths_congenital",
+      cases = "rubella_cases_congenital",
+      dalys = "dalys",
+      bypass_cert_check = TRUE,
+      lines = lines)
+    files <- data.frame(
+      touchstone = touchstone,
+      modelling_group = modelling_group,
+      disease = disease,
+      files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
+                paths$all_cal_file, paths$all_coh_file),
+      is_cohort = c(FALSE, TRUE, FALSE, TRUE),
+      is_under5 = c(TRUE, TRUE, FALSE, FALSE)
+    )
+    write.table(files, output_files, sep = ",", append = TRUE,
+                row.names = FALSE, col.names = FALSE)
+  })
 
   #############################################################################
 
@@ -417,43 +441,46 @@ do_stochastics_2021 <- function(con, test_run) {
   modelling_group = "JHU-Tam"
   disease = "Hib"
   touchstone = "202110gavi-3"
-  continue_on_error(paths <- stone_stochastic_process(
-    con,
-    modelling_group = modelling_group,
-    disease = disease,
-    touchstone = touchstone,
-    scenarios = hib_scenarios,
-    in_path = file.path(in_path, "JHU-Tam-Carter-Hib"),
-    files = ":scenario.csv.xz",
-    cert = "",
-    index_start = NA,
-    index_end = NA,
-    out_path = out_path,
-    pre_aggregation_path = pre_aggregation_path,
-    log_file = log_file,
-    deaths = c("deaths_men", "deaths_pneumo"),
-    cases = c("cases_men", "cases_pneumo"),
-    dalys = list_params_hib_pcv,
-    bypass_cert_check = TRUE,
-    lines = lines))
-  files <- data.frame(
-    touchstone = touchstone,
-    modelling_group = modelling_group,
-    disease = disease,
-    files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
-              paths$all_cal_file, paths$all_coh_file),
-    is_cohort = c(FALSE, TRUE, FALSE, TRUE),
-    is_under5 = c(TRUE, TRUE, FALSE, FALSE)
-  )
-  write.csv(files, output_files, append = TRUE, row.names = FALSE)
+  continue_on_error({
+    paths <- stone_stochastic_process(
+      con,
+      modelling_group = modelling_group,
+      disease = disease,
+      touchstone = touchstone,
+      scenarios = hib_scenarios,
+      in_path = file.path(in_path, "JHU-Tam-Carter-Hib"),
+      files = ":scenario.csv.xz",
+      cert = "",
+      index_start = NA,
+      index_end = NA,
+      out_path = out_path,
+      pre_aggregation_path = pre_aggregation_path,
+      log_file = log_file,
+      deaths = c("deaths_men", "deaths_pneumo"),
+      cases = c("cases_men", "cases_pneumo"),
+      dalys = list_params_hib_pcv,
+      bypass_cert_check = TRUE,
+      lines = lines)
+    files <- data.frame(
+      touchstone = touchstone,
+      modelling_group = modelling_group,
+      disease = disease,
+      files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
+                paths$all_cal_file, paths$all_coh_file),
+      is_cohort = c(FALSE, TRUE, FALSE, TRUE),
+      is_under5 = c(TRUE, TRUE, FALSE, FALSE)
+    )
+    write.table(files, output_files, sep = ",", append = TRUE,
+                row.names = FALSE, col.names = FALSE)
+  })
 
   # And to sort out DALYs on the centrals:
 
   for (hib_scenario in hib_scenarios) {
     stoner::stoner_dalys_for_db(con, list_params_hib_pcv, "JHU-Tam",
-      "Hib", "202110gavi-3", hib_scenario,
-    output_file = file.path(out_path, sprintf("%s_central_dalys.qs",
-                                              hib_scenario)))
+                                "Hib", "202110gavi-3", hib_scenario,
+                                output_file = file.path(out_path, sprintf("%s_central_dalys.qs",
+                                                                          hib_scenario)))
   }
 
   pcv_scenarios <- c("pcv-no-vaccination-LiST",
@@ -463,43 +490,46 @@ do_stochastics_2021 <- function(con, test_run) {
   modelling_group = "JHU-Tam"
   disease = "PCV"
   touchstone = "202110gavi-3"
-  continue_on_error(paths <- stone_stochastic_process(
-    con,
-    modelling_group = modelling_group,
-    disease = disease,
-    touchstone = touchstone,
-    scenarios = pcv_scenarios,
-    in_path = file.path(in_path, "JHU-Tam-Carter-PCV"),
-    files = ":scenario.csv.xz",
-    cert = "",
-    index_start = NA,
-    index_end = NA,
-    out_path = out_path,
-    pre_aggregation_path = pre_aggregation_path,
-    log_file = log_file,
-    deaths = c("deaths_men", "deaths_pneumo"),
-    cases = c("cases_men", "cases_pneumo"),
-    dalys = list_params_hib_pcv,
-    bypass_cert_check = TRUE,
-    lines = lines))
-  files <- data.frame(
-    touchstone = touchstone,
-    modelling_group = modelling_group,
-    disease = disease,
-    files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
-              paths$all_cal_file, paths$all_coh_file),
-    is_cohort = c(FALSE, TRUE, FALSE, TRUE),
-    is_under5 = c(TRUE, TRUE, FALSE, FALSE)
-  )
-  write.csv(files, output_files, append = TRUE, row.names = FALSE)
+  continue_on_error({
+    paths <- stone_stochastic_process(
+      con,
+      modelling_group = modelling_group,
+      disease = disease,
+      touchstone = touchstone,
+      scenarios = pcv_scenarios,
+      in_path = file.path(in_path, "JHU-Tam-Carter-PCV"),
+      files = ":scenario.csv.xz",
+      cert = "",
+      index_start = NA,
+      index_end = NA,
+      out_path = out_path,
+      pre_aggregation_path = pre_aggregation_path,
+      log_file = log_file,
+      deaths = c("deaths_men", "deaths_pneumo"),
+      cases = c("cases_men", "cases_pneumo"),
+      dalys = list_params_hib_pcv,
+      bypass_cert_check = TRUE,
+      lines = lines)
+    files <- data.frame(
+      touchstone = touchstone,
+      modelling_group = modelling_group,
+      disease = disease,
+      files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
+                paths$all_cal_file, paths$all_coh_file),
+      is_cohort = c(FALSE, TRUE, FALSE, TRUE),
+      is_under5 = c(TRUE, TRUE, FALSE, FALSE)
+    )
+    write.table(files, output_files, sep = ",", append = TRUE,
+                row.names = FALSE, col.names = FALSE)
+  })
 
   # And to sort out DALYs on the centrals:
 
   for (pcv_scenario in pcv_scenarios) {
     stoner::stoner_dalys_for_db(con, list_params_hib_pcv, "JHU-Tam",
-     "PCV", "202110gavi-3", pcv_scenario,
-         output_file = file.path(out_path, sprintf("%s_central_dalys.qs",
-         pcv_scenario)))
+                                "PCV", "202110gavi-3", pcv_scenario,
+                                output_file = file.path(out_path, sprintf("%s_central_dalys.qs",
+                                                                          pcv_scenario)))
   }
 
 
@@ -516,42 +546,45 @@ do_stochastics_2021 <- function(con, test_run) {
   modelling_group = "JHU-Tam"
   disease = "Rota"
   touchstone = "202110gavi-3"
-  continue_on_error(paths <- stone_stochastic_process(
-    con,
-    modelling_group = modelling_group,
-    disease = disease,
-    touchstone = touchstone,
-    scenarios = rota_scenarios,
-    in_path = file.path(in_path, "JHU-Tam-Carter-Rota"),
-    files = ":scenario.csv.xz",
-    cert = "",
-    index_start = NA,
-    index_end = NA,
-    out_path = out_path,
-    pre_aggregation_path = pre_aggregation_path,
-    log_file = log_file,
-    dalys = list_params_rota,
-    bypass_cert_check = TRUE,
-    lines = lines))
-  files <- data.frame(
-    touchstone = touchstone,
-    modelling_group = modelling_group,
-    disease = disease,
-    files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
-              paths$all_cal_file, paths$all_coh_file),
-    is_cohort = c(FALSE, TRUE, FALSE, TRUE),
-    is_under5 = c(TRUE, TRUE, FALSE, FALSE)
-  )
-  write.csv(files, output_files, append = TRUE, row.names = FALSE)
+  continue_on_error({
+    paths <- stone_stochastic_process(
+      con,
+      modelling_group = modelling_group,
+      disease = disease,
+      touchstone = touchstone,
+      scenarios = rota_scenarios,
+      in_path = file.path(in_path, "JHU-Tam-Carter-Rota"),
+      files = ":scenario.csv.xz",
+      cert = "",
+      index_start = NA,
+      index_end = NA,
+      out_path = out_path,
+      pre_aggregation_path = pre_aggregation_path,
+      log_file = log_file,
+      dalys = list_params_rota,
+      bypass_cert_check = TRUE,
+      lines = lines)
+    files <- data.frame(
+      touchstone = touchstone,
+      modelling_group = modelling_group,
+      disease = disease,
+      files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
+                paths$all_cal_file, paths$all_coh_file),
+      is_cohort = c(FALSE, TRUE, FALSE, TRUE),
+      is_under5 = c(TRUE, TRUE, FALSE, FALSE)
+    )
+    write.table(files, output_files, sep = ",", append = TRUE,
+                row.names = FALSE, col.names = FALSE)
+  })
 
 
   # And to sort out DALYs on the centrals:
 
   for (rota_scenario in rota_scenarios) {
     stoner::stoner_dalys_for_db(con, list_params_rota, "JHU-Tam",
-      "Rota", "202110gavi-3", rota_scenario,
-      output_file = file.path(out_path, sprintf("%s_central_dalys.qs",
-      rota_scenario)))
+                                "Rota", "202110gavi-3", rota_scenario,
+                                output_file = file.path(out_path, sprintf("%s_central_dalys.qs",
+                                                                          rota_scenario)))
   }
 
   ####################################################################################
@@ -561,84 +594,90 @@ do_stochastics_2021 <- function(con, test_run) {
   modelling_group = "KPW-Jackson"
   disease = "MenA"
   touchstone = "202110gavi-3"
-  continue_on_error(paths <- stone_stochastic_process(
-    con,
-    modelling_group = modelling_group,
-    disease = disease,
-    touchstone = touchstone,
-    scenarios = c("mena-booster-default",
-                  "mena-campaign-default",
-                  "mena-campaign-ia2030_target",
-                  "mena-no-vaccination",
-                  "mena-routine-default",
-                  "mena-routine-ia2030_target"),
-    in_path = file.path(in_path, "KPW-Jackson-MenA"),
-    files = c(paste0(stub, "booster_default_:index.csv.xz"),
-              paste0(stub, "campaign_default_:index.csv.xz"),
-              paste0(stub, "campaign_ia2030_target_:index.csv.xz"),
-              paste0(stub, "none_default_:index.csv.xz"),
-              paste0(stub, "routine_default_:index.csv.xz"),
-              paste0(stub, "routine_ia2030_target_:index.csv.xz")),
-    cert = "",
-    index_start = 1,
-    index_end = 26,
-    out_path = out_path,
-    pre_aggregation_path = pre_aggregation_path,
-    log_file = log_file,
-    bypass_cert_check = TRUE,
-    lines = lines))
-  files <- data.frame(
-    touchstone = touchstone,
-    modelling_group = modelling_group,
-    disease = disease,
-    files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
-              paths$all_cal_file, paths$all_coh_file),
-    is_cohort = c(FALSE, TRUE, FALSE, TRUE),
-    is_under5 = c(TRUE, TRUE, FALSE, FALSE)
-  )
-  write.csv(files, output_files, append = TRUE, row.names = FALSE)
+  continue_on_error({
+    paths <- stone_stochastic_process(
+      con,
+      modelling_group = modelling_group,
+      disease = disease,
+      touchstone = touchstone,
+      scenarios = c("mena-booster-default",
+                    "mena-campaign-default",
+                    "mena-campaign-ia2030_target",
+                    "mena-no-vaccination",
+                    "mena-routine-default",
+                    "mena-routine-ia2030_target"),
+      in_path = file.path(in_path, "KPW-Jackson-MenA"),
+      files = c(paste0(stub, "booster_default_:index.csv.xz"),
+                paste0(stub, "campaign_default_:index.csv.xz"),
+                paste0(stub, "campaign_ia2030_target_:index.csv.xz"),
+                paste0(stub, "none_default_:index.csv.xz"),
+                paste0(stub, "routine_default_:index.csv.xz"),
+                paste0(stub, "routine_ia2030_target_:index.csv.xz")),
+      cert = "",
+      index_start = 1,
+      index_end = 26,
+      out_path = out_path,
+      pre_aggregation_path = pre_aggregation_path,
+      log_file = log_file,
+      bypass_cert_check = TRUE,
+      lines = lines)
+    files <- data.frame(
+      touchstone = touchstone,
+      modelling_group = modelling_group,
+      disease = disease,
+      files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
+                paths$all_cal_file, paths$all_coh_file),
+      is_cohort = c(FALSE, TRUE, FALSE, TRUE),
+      is_under5 = c(TRUE, TRUE, FALSE, FALSE)
+    )
+    write.table(files, output_files, sep = ",", append = TRUE,
+                row.names = FALSE, col.names = FALSE)
+  })
 
   #############################################################################
 
   modelling_group = "Li"
   disease = "HepB"
   touchstone = "202110gavi-2"
-  continue_on_error(paths <- stone_stochastic_process(
-    con,
-    modelling_group = modelling_group,
-    disease = disease,
-    touchstone = touchstone,
-    scenarios = c("hepb-bd-default-hepb-routine-default",
-                  "hepb-bd-routine-default",
-                  "hepb-bd-routine-ia2030_target-hepb-routine-ia2030_target",
-                  "hepb-bd-routine-ia2030_target",
-                  "hepb-hepb-routine-default",
-                  "hepb-hepb-routine-ia2030_target",
-                  "hepb-no-vaccination"
-    ),
-    in_path = file.path(in_path, "Li"),
-    files = paste0(":scenario:index.csv.xz"),
-    cert = "cert105",
-    index_start = 1,
-    index_end = 200,
-    out_path = out_path,
-    pre_aggregation_path = pre_aggregation_path,
-    log_file = log_file,
-    deaths = c("hepb_deaths_acute", "hepb_deaths_total_cirrh", "hepb_deaths_hcc"),
-    cases = c("hepb_cases_acute_symp", "hepb_cases_fulminant",
-              "hepb_cases_chronic", "hepb_chronic_symptomatic_in_acute_phase"),
-    dalys = "dalys",
-    lines = lines))
-  files <- data.frame(
-    touchstone = touchstone,
-    modelling_group = modelling_group,
-    disease = disease,
-    files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
-              paths$all_cal_file, paths$all_coh_file),
-    is_cohort = c(FALSE, TRUE, FALSE, TRUE),
-    is_under5 = c(TRUE, TRUE, FALSE, FALSE)
-  )
-  write.csv(files, output_files, append = TRUE, row.names = FALSE)
+  continue_on_error({
+    paths <- stone_stochastic_process(
+      con,
+      modelling_group = modelling_group,
+      disease = disease,
+      touchstone = touchstone,
+      scenarios = c("hepb-bd-default-hepb-routine-default",
+                    "hepb-bd-routine-default",
+                    "hepb-bd-routine-ia2030_target-hepb-routine-ia2030_target",
+                    "hepb-bd-routine-ia2030_target",
+                    "hepb-hepb-routine-default",
+                    "hepb-hepb-routine-ia2030_target",
+                    "hepb-no-vaccination"
+      ),
+      in_path = file.path(in_path, "Li"),
+      files = paste0(":scenario:index.csv.xz"),
+      cert = "cert105",
+      index_start = 1,
+      index_end = 200,
+      out_path = out_path,
+      pre_aggregation_path = pre_aggregation_path,
+      log_file = log_file,
+      deaths = c("hepb_deaths_acute", "hepb_deaths_total_cirrh", "hepb_deaths_hcc"),
+      cases = c("hepb_cases_acute_symp", "hepb_cases_fulminant",
+                "hepb_cases_chronic", "hepb_chronic_symptomatic_in_acute_phase"),
+      dalys = "dalys",
+      lines = lines)
+    files <- data.frame(
+      touchstone = touchstone,
+      modelling_group = modelling_group,
+      disease = disease,
+      files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
+                paths$all_cal_file, paths$all_coh_file),
+      is_cohort = c(FALSE, TRUE, FALSE, TRUE),
+      is_under5 = c(TRUE, TRUE, FALSE, FALSE)
+    )
+    write.table(files, output_files, sep = ",", append = TRUE,
+                row.names = FALSE, col.names = FALSE)
+  })
 
   #############################################################################
 
@@ -646,31 +685,34 @@ do_stochastics_2021 <- function(con, test_run) {
   modelling_group = "LSHTM-Clark"
   disease = "Hib"
   touchstone = "202110gavi-3"
-  continue_on_error(paths <- stone_stochastic_process(
-    con,
-    modelling_group = modelling_group,
-    disease = disease,
-    touchstone = touchstone,
-    scenarios = c("hib-no-vaccination","hib-routine-default","hib-routine-ia2030_target"),
-    in_path = file.path(in_path, "LSHTM-Clark_Hib"),
-    files = c(paste0(stub, ":scenario.csv.xz")),
-    cert = "Kaja Abbas - hib_cert116",
-    index_start = NA,
-    index_end = NA,
-    out_path = out_path,
-    pre_aggregation_path = pre_aggregation_path,
-    log_file = log_file,
-    lines = lines))
-  files <- data.frame(
-    touchstone = touchstone,
-    modelling_group = modelling_group,
-    disease = disease,
-    files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
-              paths$all_cal_file, paths$all_coh_file),
-    is_cohort = c(FALSE, TRUE, FALSE, TRUE),
-    is_under5 = c(TRUE, TRUE, FALSE, FALSE)
-  )
-  write.csv(files, output_files, append = TRUE, row.names = FALSE)
+  continue_on_error({
+    paths <- stone_stochastic_process(
+      con,
+      modelling_group = modelling_group,
+      disease = disease,
+      touchstone = touchstone,
+      scenarios = c("hib-no-vaccination","hib-routine-default","hib-routine-ia2030_target"),
+      in_path = file.path(in_path, "LSHTM-Clark_Hib"),
+      files = c(paste0(stub, ":scenario.csv.xz")),
+      cert = "Kaja Abbas - hib_cert116",
+      index_start = NA,
+      index_end = NA,
+      out_path = out_path,
+      pre_aggregation_path = pre_aggregation_path,
+      log_file = log_file,
+      lines = lines)
+    files <- data.frame(
+      touchstone = touchstone,
+      modelling_group = modelling_group,
+      disease = disease,
+      files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
+                paths$all_cal_file, paths$all_coh_file),
+      is_cohort = c(FALSE, TRUE, FALSE, TRUE),
+      is_under5 = c(TRUE, TRUE, FALSE, FALSE)
+    )
+    write.table(files, output_files, sep = ",", append = TRUE,
+                row.names = FALSE, col.names = FALSE)
+  })
 
   #############################################################################
 
@@ -679,31 +721,34 @@ do_stochastics_2021 <- function(con, test_run) {
   modelling_group = "LSHTM-Clark"
   disease = "Rota"
   touchstone = "202110gavi-3"
-  continue_on_error(paths <- stone_stochastic_process(
-    con,
-    modelling_group = modelling_group,
-    disease = disease,
-    touchstone = touchstone,
-    scenarios = c("rota-no-vaccination","rota-routine-default","rota-routine-ia2030_target"),
-    in_path = file.path(in_path, "LSHTM-Clark_Rota"),
-    files = c(paste0(stub, ":scenario.csv.xz")),
-    cert = "Kaja Abbas - rota_cert117",
-    index_start = NA,
-    index_end = NA,
-    out_path = out_path,
-    pre_aggregation_path = pre_aggregation_path,
-    log_file = log_file,
-    lines = lines))
-  files <- data.frame(
-    touchstone = touchstone,
-    modelling_group = modelling_group,
-    disease = disease,
-    files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
-              paths$all_cal_file, paths$all_coh_file),
-    is_cohort = c(FALSE, TRUE, FALSE, TRUE),
-    is_under5 = c(TRUE, TRUE, FALSE, FALSE)
-  )
-  write.csv(files, output_files, append = TRUE, row.names = FALSE)
+  continue_on_error({
+    paths <- stone_stochastic_process(
+      con,
+      modelling_group = modelling_group,
+      disease = disease,
+      touchstone = touchstone,
+      scenarios = c("rota-no-vaccination","rota-routine-default","rota-routine-ia2030_target"),
+      in_path = file.path(in_path, "LSHTM-Clark_Rota"),
+      files = c(paste0(stub, ":scenario.csv.xz")),
+      cert = "Kaja Abbas - rota_cert117",
+      index_start = NA,
+      index_end = NA,
+      out_path = out_path,
+      pre_aggregation_path = pre_aggregation_path,
+      log_file = log_file,
+      lines = lines)
+    files <- data.frame(
+      touchstone = touchstone,
+      modelling_group = modelling_group,
+      disease = disease,
+      files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
+                paths$all_cal_file, paths$all_coh_file),
+      is_cohort = c(FALSE, TRUE, FALSE, TRUE),
+      is_under5 = c(TRUE, TRUE, FALSE, FALSE)
+    )
+    write.table(files, output_files, sep = ",", append = TRUE,
+                row.names = FALSE, col.names = FALSE)
+  })
 
   #############################################################################
 
@@ -712,37 +757,40 @@ do_stochastics_2021 <- function(con, test_run) {
   modelling_group = "LSHTM-Jit"
   disease = "HPV"
   touchstone = "202110gavi-3"
-  continue_on_error(paths <- stone_stochastic_process(
-    con,
-    modelling_group = modelling_group,
-    disease = disease,
-    touchstone = touchstone,
-    scenarios = c("hpv-no-vaccination",
-                  "hpv-campaign-default",
-                  "hpv-routine-default",
-                  "hpv-campaign-ia2030_target",
-                  "hpv-routine-ia2030_target"),
-    in_path = file.path(in_path, "LSHTM-Jit_HPV"),
-    files = c(paste0(stub, "novaccination_all_202110gavi-3_hpv-no-vaccination.csv.xz"),
-              paste0(stub, "vaccination_all_202110gavi-3_hpv-campaign-default.csv.xz"),
-              paste0(stub, "vaccination_all_202110gavi-3_hpv-routine-default.csv.xz"),
-              paste0(stub, "vaccination_all_202110gavi-3_hpv-campaign-ia2030_target.csv.xz"),
-              paste0(stub, "vaccination_all_202110gavi-3_hpv-routine-ia2030_target.csv.xz")),
-    cert = "cert104", index_start = NA, index_end = NA, out_path = out_path,
-    pre_aggregation_path = pre_aggregation_path,
-    log_file = log_file,
-    bypass_cert_check = TRUE,
-    lines = lines))
-  files <- data.frame(
-    touchstone = touchstone,
-    modelling_group = modelling_group,
-    disease = disease,
-    files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
-              paths$all_cal_file, paths$all_coh_file),
-    is_cohort = c(FALSE, TRUE, FALSE, TRUE),
-    is_under5 = c(TRUE, TRUE, FALSE, FALSE)
-  )
-  write.csv(files, output_files, append = TRUE, row.names = FALSE)
+  continue_on_error({
+    paths <- stone_stochastic_process(
+      con,
+      modelling_group = modelling_group,
+      disease = disease,
+      touchstone = touchstone,
+      scenarios = c("hpv-no-vaccination",
+                    "hpv-campaign-default",
+                    "hpv-routine-default",
+                    "hpv-campaign-ia2030_target",
+                    "hpv-routine-ia2030_target"),
+      in_path = file.path(in_path, "LSHTM-Jit_HPV"),
+      files = c(paste0(stub, "novaccination_all_202110gavi-3_hpv-no-vaccination.csv.xz"),
+                paste0(stub, "vaccination_all_202110gavi-3_hpv-campaign-default.csv.xz"),
+                paste0(stub, "vaccination_all_202110gavi-3_hpv-routine-default.csv.xz"),
+                paste0(stub, "vaccination_all_202110gavi-3_hpv-campaign-ia2030_target.csv.xz"),
+                paste0(stub, "vaccination_all_202110gavi-3_hpv-routine-ia2030_target.csv.xz")),
+      cert = "cert104", index_start = NA, index_end = NA, out_path = out_path,
+      pre_aggregation_path = pre_aggregation_path,
+      log_file = log_file,
+      bypass_cert_check = TRUE,
+      lines = lines)
+    files <- data.frame(
+      touchstone = touchstone,
+      modelling_group = modelling_group,
+      disease = disease,
+      files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
+                paths$all_cal_file, paths$all_coh_file),
+      is_cohort = c(FALSE, TRUE, FALSE, TRUE),
+      is_under5 = c(TRUE, TRUE, FALSE, FALSE)
+    )
+    write.table(files, output_files, sep = ",", append = TRUE,
+                row.names = FALSE, col.names = FALSE)
+  })
 
   #############################################################################
 
@@ -750,47 +798,50 @@ do_stochastics_2021 <- function(con, test_run) {
   modelling_group = "LSHTM-Jit"
   disease = "Measles"
   touchstone = "202110gavi-3"
-  continue_on_error(paths <- stone_stochastic_process(
-    con,
-    modelling_group = modelling_group,
-    disease = disease,
-    touchstone = touchstone,
-    scenarios = c("measles-no-vaccination",
-                  "measles-campaign-default",
-                  "measles-campaign-only-default",
-                  "measles-mcv1-default",
-                  "measles-mcv2-default",
-                  "measles-campaign-ia2030_target",
-                  "measles-campaign-only-ia2030_target",
-                  "measles-mcv1-ia2030_target",
-                  "measles-mcv2-ia2030_target"),
-    in_path = file.path(in_path, "LSHTM-Jit_Measles"),
-    files = c(paste0(stub, "no-vaccination.csv.xz"),
-              paste0(stub, "campaign-default.csv.xz"),
-              paste0(stub, "campaign-only-default.csv.xz"),
-              paste0(stub, "mcv1-default.csv.xz"),
-              paste0(stub, "mcv2-default.csv.xz"),
-              paste0(stub, "campaign-ia2030_target.csv.xz"),
-              paste0(stub, "campaign-only-ia2030_target.csv.xz"),
-              paste0(stub, "mcv1-ia2030_target.csv.xz"),
-              paste0(stub, "mcv2-ia2030_target.csv.xz")),
-    cert = "Han Fu - cert112_measles-LSHTM-Jit_202110gavi-3",
-    index_start = NA,
-    index_end = NA,
-    out_path = out_path,
-    pre_aggregation_path = pre_aggregation_path,
-    log_file = log_file,
-    lines = lines))
-  files <- data.frame(
-    touchstone = touchstone,
-    modelling_group = modelling_group,
-    disease = disease,
-    files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
-              paths$all_cal_file, paths$all_coh_file),
-    is_cohort = c(FALSE, TRUE, FALSE, TRUE),
-    is_under5 = c(TRUE, TRUE, FALSE, FALSE)
-  )
-  write.csv(files, output_files, append = TRUE, row.names = FALSE)
+  continue_on_error({
+    paths <- stone_stochastic_process(
+      con,
+      modelling_group = modelling_group,
+      disease = disease,
+      touchstone = touchstone,
+      scenarios = c("measles-no-vaccination",
+                    "measles-campaign-default",
+                    "measles-campaign-only-default",
+                    "measles-mcv1-default",
+                    "measles-mcv2-default",
+                    "measles-campaign-ia2030_target",
+                    "measles-campaign-only-ia2030_target",
+                    "measles-mcv1-ia2030_target",
+                    "measles-mcv2-ia2030_target"),
+      in_path = file.path(in_path, "LSHTM-Jit_Measles"),
+      files = c(paste0(stub, "no-vaccination.csv.xz"),
+                paste0(stub, "campaign-default.csv.xz"),
+                paste0(stub, "campaign-only-default.csv.xz"),
+                paste0(stub, "mcv1-default.csv.xz"),
+                paste0(stub, "mcv2-default.csv.xz"),
+                paste0(stub, "campaign-ia2030_target.csv.xz"),
+                paste0(stub, "campaign-only-ia2030_target.csv.xz"),
+                paste0(stub, "mcv1-ia2030_target.csv.xz"),
+                paste0(stub, "mcv2-ia2030_target.csv.xz")),
+      cert = "Han Fu - cert112_measles-LSHTM-Jit_202110gavi-3",
+      index_start = NA,
+      index_end = NA,
+      out_path = out_path,
+      pre_aggregation_path = pre_aggregation_path,
+      log_file = log_file,
+      lines = lines)
+    files <- data.frame(
+      touchstone = touchstone,
+      modelling_group = modelling_group,
+      disease = disease,
+      files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
+                paths$all_cal_file, paths$all_coh_file),
+      is_cohort = c(FALSE, TRUE, FALSE, TRUE),
+      is_under5 = c(TRUE, TRUE, FALSE, FALSE)
+    )
+    write.table(files, output_files, sep = ",", append = TRUE,
+                row.names = FALSE, col.names = FALSE)
+  })
 
   #############################################################################
 
@@ -798,82 +849,88 @@ do_stochastics_2021 <- function(con, test_run) {
   modelling_group = "NUS-Chen"
   disease = "PCV"
   touchstone = "202110gavi-3"
-  continue_on_error(paths <- stone_stochastic_process(
-    con,
-    modelling_group = modelling_group,
-    disease = disease,
-    touchstone = touchstone,
-    scenarios = c("pcv-no-vaccination","pcv-routine-default","pcv-routine-ia2030_target"),
-    in_path = file.path(in_path, "LSHTM-NUS-Chen_PCV"),
-    files = paste0(stub, ":scenario.csv.xz"),
-    cert = "Jemima Koh - cert121",
-    index_start = NA,
-    index_end = NA,
-    out_path = out_path,
-    pre_aggregation_path = pre_aggregation_path,
-    log_file = log_file,
-    lines = lines))
-  files <- data.frame(
-    touchstone = touchstone,
-    modelling_group = modelling_group,
-    disease = disease,
-    files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
-              paths$all_cal_file, paths$all_coh_file),
-    is_cohort = c(FALSE, TRUE, FALSE, TRUE),
-    is_under5 = c(TRUE, TRUE, FALSE, FALSE)
-  )
-  write.csv(files, output_files, append = TRUE, row.names = FALSE)
+  continue_on_error({
+    paths <- stone_stochastic_process(
+      con,
+      modelling_group = modelling_group,
+      disease = disease,
+      touchstone = touchstone,
+      scenarios = c("pcv-no-vaccination","pcv-routine-default","pcv-routine-ia2030_target"),
+      in_path = file.path(in_path, "LSHTM-NUS-Chen_PCV"),
+      files = paste0(stub, ":scenario.csv.xz"),
+      cert = "Jemima Koh - cert121",
+      index_start = NA,
+      index_end = NA,
+      out_path = out_path,
+      pre_aggregation_path = pre_aggregation_path,
+      log_file = log_file,
+      lines = lines)
+    files <- data.frame(
+      touchstone = touchstone,
+      modelling_group = modelling_group,
+      disease = disease,
+      files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
+                paths$all_cal_file, paths$all_coh_file),
+      is_cohort = c(FALSE, TRUE, FALSE, TRUE),
+      is_under5 = c(TRUE, TRUE, FALSE, FALSE)
+    )
+    write.table(files, output_files, sep = ",", append = TRUE,
+                row.names = FALSE, col.names = FALSE)
+  })
 
   #############################################################################
 
   modelling_group = "PHE-Vynnycky"
   disease = "Rubella"
   touchstone = "202110gavi-3"
-  continue_on_error(paths <- stone_stochastic_process(
-    con,
-    modelling_group = modelling_group,
-    disease = disease,
-    touchstone = touchstone,
-    scenarios = c("rubella-routine-no-vaccination",
-                  "rubella-campaign-default",
-                  "rubella-rcv1-default",
-                  "rubella-rcv2-default",
-                  "rubella-rcv1-rcv2-default",
-                  "rubella-campaign-ia2030_target",
-                  "rubella-rcv1-ia2030_target",
-                  "rubella-rcv2-ia2030_target",
-                  "rubella-rcv1-rcv2-ia2030_target"),
-    in_path = file.path(in_path, "PHE-Vynnycky_Rubella"),
-    files = c("VIMC_NV_RCV1RCV2Camp_country:index.csv.xz",
-              "VIMC_DF_Camp_country:index.csv.xz",
-              "VIMC_DF_RCV1Camp_country:index.csv.xz",
-              "VIMC_DF_RCV1RCV2Camp_country:index.csv.xz",
-              "VIMC_DF_RCV1RCV2_country:index.csv.xz",
-              "VIMC_IA_Camp_country:index.csv.xz",
-              "VIMC_IA_RCV1Camp_country:index.csv.xz",
-              "VIMC_IA_RCV1RCV2Camp_country:index.csv.xz",
-              "VIMC_IA_RCV1RCV2_country:index.csv.xz"),
-    cert = "",
-    index_start = 1,
-    index_end = 112,
-    out_path = out_path,
-    pre_aggregation_path = pre_aggregation_path,
-    log_file = log_file,
-    deaths = "rubella_deaths_congenital",
-    cases = "rubella_cases_congenital",
-    dalys = "dalys",
-    bypass_cert_check = TRUE,
-    lines = lines))
-  files <- data.frame(
-    touchstone = touchstone,
-    modelling_group = modelling_group,
-    disease = disease,
-    files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
-              paths$all_cal_file, paths$all_coh_file),
-    is_cohort = c(FALSE, TRUE, FALSE, TRUE),
-    is_under5 = c(TRUE, TRUE, FALSE, FALSE)
-  )
-  write.csv(files, output_files, append = TRUE, row.names = FALSE)
+  continue_on_error({
+    paths <- stone_stochastic_process(
+      con,
+      modelling_group = modelling_group,
+      disease = disease,
+      touchstone = touchstone,
+      scenarios = c("rubella-routine-no-vaccination",
+                    "rubella-campaign-default",
+                    "rubella-rcv1-default",
+                    "rubella-rcv2-default",
+                    "rubella-rcv1-rcv2-default",
+                    "rubella-campaign-ia2030_target",
+                    "rubella-rcv1-ia2030_target",
+                    "rubella-rcv2-ia2030_target",
+                    "rubella-rcv1-rcv2-ia2030_target"),
+      in_path = file.path(in_path, "PHE-Vynnycky_Rubella"),
+      files = c("VIMC_NV_RCV1RCV2Camp_country:index.csv.xz",
+                "VIMC_DF_Camp_country:index.csv.xz",
+                "VIMC_DF_RCV1Camp_country:index.csv.xz",
+                "VIMC_DF_RCV1RCV2Camp_country:index.csv.xz",
+                "VIMC_DF_RCV1RCV2_country:index.csv.xz",
+                "VIMC_IA_Camp_country:index.csv.xz",
+                "VIMC_IA_RCV1Camp_country:index.csv.xz",
+                "VIMC_IA_RCV1RCV2Camp_country:index.csv.xz",
+                "VIMC_IA_RCV1RCV2_country:index.csv.xz"),
+      cert = "",
+      index_start = 1,
+      index_end = 112,
+      out_path = out_path,
+      pre_aggregation_path = pre_aggregation_path,
+      log_file = log_file,
+      deaths = "rubella_deaths_congenital",
+      cases = "rubella_cases_congenital",
+      dalys = "dalys",
+      bypass_cert_check = TRUE,
+      lines = lines)
+    files <- data.frame(
+      touchstone = touchstone,
+      modelling_group = modelling_group,
+      disease = disease,
+      files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
+                paths$all_cal_file, paths$all_coh_file),
+      is_cohort = c(FALSE, TRUE, FALSE, TRUE),
+      is_under5 = c(TRUE, TRUE, FALSE, FALSE)
+    )
+    write.table(files, output_files, sep = ",", append = TRUE,
+                row.names = FALSE, col.names = FALSE)
+  })
 
   #############################################################################
 
@@ -881,30 +938,43 @@ do_stochastics_2021 <- function(con, test_run) {
   modelling_group = "PSU-Ferrari"
   disease = "Measles"
   touchstone = "202110gavi-3"
-  continue_on_error(paths <- stone_stochastic_process(
-    con,
-    modelling_group = modelling_group,
-    disease = disease,
-    touchstone = touchstone,
-    scenarios = c("measles-campaign-default",
-                  "measles-campaign-ia2030_target",
-                  "measles-campaign-only-default",
-                  "measles-campaign-only-ia2030_target",
-                  "measles-mcv1-default",
-                  "measles-mcv1-ia2030_target",
-                  "measles-mcv2-default",
-                  "measles-mcv2-ia2030_target",
-                  "measles-no-vaccination"),
-    in_path = file.path(in_path, "PSU-Ferrari-Measles"),
-    files = paste0(stub, ":scenario.csv.xz"),
-    cert = "",
-    index_start = NA,
-    index_end = NA,
-    out_path = out_path,
-    pre_aggregation_path = pre_aggregation_path,
-    log_file = log_file,
-    bypass_cert_check = TRUE,
-    lines = lines))
+  continue_on_error({
+    paths <- stone_stochastic_process(
+      con,
+      modelling_group = modelling_group,
+      disease = disease,
+      touchstone = touchstone,
+      scenarios = c("measles-campaign-default",
+                    "measles-campaign-ia2030_target",
+                    "measles-campaign-only-default",
+                    "measles-campaign-only-ia2030_target",
+                    "measles-mcv1-default",
+                    "measles-mcv1-ia2030_target",
+                    "measles-mcv2-default",
+                    "measles-mcv2-ia2030_target",
+                    "measles-no-vaccination"),
+      in_path = file.path(in_path, "PSU-Ferrari-Measles"),
+      files = paste0(stub, ":scenario.csv.xz"),
+      cert = "",
+      index_start = NA,
+      index_end = NA,
+      out_path = out_path,
+      pre_aggregation_path = pre_aggregation_path,
+      log_file = log_file,
+      bypass_cert_check = TRUE,
+      lines = lines)
+    files <- data.frame(
+      touchstone = touchstone,
+      modelling_group = modelling_group,
+      disease = disease,
+      files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
+                paths$all_cal_file, paths$all_coh_file),
+      is_cohort = c(FALSE, TRUE, FALSE, TRUE),
+      is_under5 = c(TRUE, TRUE, FALSE, FALSE)
+    )
+    write.table(files, output_files, sep = ",", append = TRUE,
+                row.names = FALSE, col.names = FALSE)
+  })
 
   #############################################################################
 
@@ -912,36 +982,39 @@ do_stochastics_2021 <- function(con, test_run) {
   modelling_group = "UND-Moore"
   disease = "JE"
   touchstone = "202110gavi-2"
-  continue_on_error(paths <- stone_stochastic_process(
-    con,
-    modelling_group = modelling_group,
-    disease = disease,
-    touchstone = touchstone,
-    scenarios = c("je-routine-no-vaccination",
-                  "je-campaign-default",
-                  "je-routine-default",
-                  "je-campaign-ia2030_target",
-                  "je-routine-ia2030_target"
-    ),
-    in_path = file.path(in_path, "UND-Moore-JE"),
-    files = paste0(stub, ":scenario.csv.xz"),
-    cert = "Sean Moore - cert108",
-    index_start = NA,
-    index_end = NA,
-    out_path = out_path,
-    pre_aggregation_path = pre_aggregation_path,
-    log_file = log_file,
-    lines = lines))
-  files <- data.frame(
-    touchstone = touchstone,
-    modelling_group = modelling_group,
-    disease = disease,
-    files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
-              paths$all_cal_file, paths$all_coh_file),
-    is_cohort = c(FALSE, TRUE, FALSE, TRUE),
-    is_under5 = c(TRUE, TRUE, FALSE, FALSE)
-  )
-  write.csv(files, output_files, append = TRUE, row.names = FALSE)
+  continue_on_error({
+    paths <- stone_stochastic_process(
+      con,
+      modelling_group = modelling_group,
+      disease = disease,
+      touchstone = touchstone,
+      scenarios = c("je-routine-no-vaccination",
+                    "je-campaign-default",
+                    "je-routine-default",
+                    "je-campaign-ia2030_target",
+                    "je-routine-ia2030_target"
+      ),
+      in_path = file.path(in_path, "UND-Moore-JE"),
+      files = paste0(stub, ":scenario.csv.xz"),
+      cert = "Sean Moore - cert108",
+      index_start = NA,
+      index_end = NA,
+      out_path = out_path,
+      pre_aggregation_path = pre_aggregation_path,
+      log_file = log_file,
+      lines = lines)
+    files <- data.frame(
+      touchstone = touchstone,
+      modelling_group = modelling_group,
+      disease = disease,
+      files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
+                paths$all_cal_file, paths$all_coh_file),
+      is_cohort = c(FALSE, TRUE, FALSE, TRUE),
+      is_under5 = c(TRUE, TRUE, FALSE, FALSE)
+    )
+    write.table(files, output_files, sep = ",", append = TRUE,
+                row.names = FALSE, col.names = FALSE)
+  })
 
 
   #############################################################################
@@ -951,36 +1024,39 @@ do_stochastics_2021 <- function(con, test_run) {
   modelling_group = "UND-Perkins"
   disease = "YF"
   touchstone = "202110gavi-3"
-  continue_on_error(paths <- stone_stochastic_process(
-    con,
-    modelling_group = modelling_group,
-    disease = disease,
-    touchstone = touchstone,
-    scenarios = c("yf-no-vaccination",
-                  "yf-preventive-default",
-                  "yf-preventive-ia2030_target",
-                  "yf-routine-default",
-                  "yf-routine-ia2030_target"),
-    in_path = file.path(in_path, "UND-Perkins-YF"),
-    files = paste0(stub, ":scenario_:index.csv.xz"),
-    cert = "",
-    index_start = 1,
-    index_end = 200,
-    out_path = out_path,
-    pre_aggregation_path = pre_aggregation_path,
-    log_file = log_file,
-    bypass_cert_check = TRUE,
-    lines = lines))
-  files <- data.frame(
-    touchstone = touchstone,
-    modelling_group = modelling_group,
-    disease = disease,
-    files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
-              paths$all_cal_file, paths$all_coh_file),
-    is_cohort = c(FALSE, TRUE, FALSE, TRUE),
-    is_under5 = c(TRUE, TRUE, FALSE, FALSE)
-  )
-  write.csv(files, output_files, append = TRUE, row.names = FALSE)
+  continue_on_error({
+    paths <- stone_stochastic_process(
+      con,
+      modelling_group = modelling_group,
+      disease = disease,
+      touchstone = touchstone,
+      scenarios = c("yf-no-vaccination",
+                    "yf-preventive-default",
+                    "yf-preventive-ia2030_target",
+                    "yf-routine-default",
+                    "yf-routine-ia2030_target"),
+      in_path = file.path(in_path, "UND-Perkins-YF"),
+      files = paste0(stub, ":scenario_:index.csv.xz"),
+      cert = "",
+      index_start = 1,
+      index_end = 200,
+      out_path = out_path,
+      pre_aggregation_path = pre_aggregation_path,
+      log_file = log_file,
+      bypass_cert_check = TRUE,
+      lines = lines)
+    files <- data.frame(
+      touchstone = touchstone,
+      modelling_group = modelling_group,
+      disease = disease,
+      files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
+                paths$all_cal_file, paths$all_coh_file),
+      is_cohort = c(FALSE, TRUE, FALSE, TRUE),
+      is_under5 = c(TRUE, TRUE, FALSE, FALSE)
+    )
+    write.table(files, output_files, sep = ",", append = TRUE,
+                row.names = FALSE, col.names = FALSE)
+  })
 
 
   #############################################################################
@@ -990,38 +1066,41 @@ do_stochastics_2021 <- function(con, test_run) {
   modelling_group = "Yale-Pitzer"
   disease = "Typhoid"
   touchstone = "202110gavi-3"
-  continue_on_error(paths <- stone_stochastic_process(
-    con,
-    modelling_group = modelling_group,
-    disease = disease,
-    touchstone = touchstone,
-    scenarios = c("typhoid-no-vaccination",
-                  "typhoid-campaign-default", "typhoid-campaign-ia2030_target",
-                  "typhoid-routine-default",  "typhoid-routine-ia2030_target"),
-    in_path = file.path(in_path, "Yale-Pitzer-Typhoid"),
-    files = c(paste0(stub, "-novacc_202110.csv.xz"),
-              paste0(stub, "_campaign-default_202110.csv.xz"),
-              paste0(stub, "_campaign-IA2030_202110.csv.xz"),
-              paste0(stub, "_routine-default_202110.csv.xz"),
-              paste0(stub, "_routine-IA2030_202110.csv.xz")),
-    cert = "",
-    index_start = NA,
-    index_end = NA,
-    out_path = out_path,
-    pre_aggregation_path = pre_aggregation_path,
-    log_file = log_file,
-    bypass_cert_check = TRUE,
-    lines = lines))
-  files <- data.frame(
-    touchstone = touchstone,
-    modelling_group = modelling_group,
-    disease = disease,
-    files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
-              paths$all_cal_file, paths$all_coh_file),
-    is_cohort = c(FALSE, TRUE, FALSE, TRUE),
-    is_under5 = c(TRUE, TRUE, FALSE, FALSE)
-  )
-  write.csv(files, output_files, append = TRUE, row.names = FALSE)
+  continue_on_error({
+    paths <- stone_stochastic_process(
+      con,
+      modelling_group = modelling_group,
+      disease = disease,
+      touchstone = touchstone,
+      scenarios = c("typhoid-no-vaccination",
+                    "typhoid-campaign-default", "typhoid-campaign-ia2030_target",
+                    "typhoid-routine-default",  "typhoid-routine-ia2030_target"),
+      in_path = file.path(in_path, "Yale-Pitzer-Typhoid"),
+      files = c(paste0(stub, "-novacc_202110.csv.xz"),
+                paste0(stub, "_campaign-default_202110.csv.xz"),
+                paste0(stub, "_campaign-IA2030_202110.csv.xz"),
+                paste0(stub, "_routine-default_202110.csv.xz"),
+                paste0(stub, "_routine-IA2030_202110.csv.xz")),
+      cert = "",
+      index_start = NA,
+      index_end = NA,
+      out_path = out_path,
+      pre_aggregation_path = pre_aggregation_path,
+      log_file = log_file,
+      bypass_cert_check = TRUE,
+      lines = lines)
+    files <- data.frame(
+      touchstone = touchstone,
+      modelling_group = modelling_group,
+      disease = disease,
+      files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
+                paths$all_cal_file, paths$all_coh_file),
+      is_cohort = c(FALSE, TRUE, FALSE, TRUE),
+      is_under5 = c(TRUE, TRUE, FALSE, FALSE)
+    )
+    write.table(files, output_files, sep = ",", append = TRUE,
+                row.names = FALSE, col.names = FALSE)
+  })
 }
 
 do_stochastics_2019 <- function(con, test_run) {

--- a/scripts/run_stochastic_process.R
+++ b/scripts/run_stochastic_process.R
@@ -25,19 +25,31 @@ do_stochastics_2021 <- function(con, test_run) {
   out_path <- "Z:/stochastic_2021_output/aggregated/"
   pre_aggregation_path <- "Z:/stochastic_2021_output/pre-aggregate/"
   log_file <- "Z:/stochastic_2021_output/log.txt"
+  output_files <- "Z:/stochastic_2021_output/output_files.csv"
+  files <- data.frame(
+    touchstone = character(0),
+    modelling_group = character(0),
+    disease = character(0),
+    files = character(0),
+    is_cohort = logical(0),
+    is_under5 = logical(0)
+  )
+  write.csv(files, output_files, row.names = FALSE)
 
   lines <- Inf
   if (isTRUE(test_run)) {
     lines <- 30
   }
 
-
   stub <- "Andromachi Karachaliou - stochastic-burden.202110gavi-2.MenA_Cambridge-Trotter_"
-  continue_on_error(stone_stochastic_process(
+  modelling_group = "Cambridge-Trotter"
+  disease = "MenA"
+  touchstone = "202110gavi-3"
+  continue_on_error(paths <- stone_stochastic_process(
     con,
-    modelling_group = "Cambridge-Trotter",
-    disease = "MenA",
-    touchstone = "202110gavi-3",
+    modelling_group = modelling_group,
+    disease = disease,
+    touchstone = touchstone,
     scenarios = c("mena-no-vaccination", "mena-campaign-default",
                   "mena-routine-default", "mena-booster-default",
                   "mena-campaign-ia2030_target", "mena-routine-ia2030_target"),
@@ -56,15 +68,28 @@ do_stochastics_2021 <- function(con, test_run) {
     log_file = log_file,
     bypass_cert_check = TRUE,
     lines = lines))
+  files <- data.frame(
+    touchstone = touchstone,
+    modelling_group = modelling_group,
+    disease = disease,
+    files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
+              paths$all_cal_file, paths$all_coh_file),
+    is_cohort = c(FALSE, TRUE, FALSE, TRUE),
+    is_under5 = c(TRUE, TRUE, FALSE, FALSE)
+  )
+  write.csv(files, output_files, append = TRUE, row.names = FALSE)
 
   #############################################################################
 
   stub <- "Aniruddha Deshpande - stochastic_burden_est_lopman_"
-  continue_on_error(stone_stochastic_process(
+  modelling_group = "Emory-Lopman"
+  disease = "Rota"
+  touchstone = "202110gavi-3"
+  continue_on_error(paths <- stone_stochastic_process(
     con,
-    modelling_group = "Emory-Lopman",
-    disease = "Rota",
-    touchstone = "202110gavi-3",
+    modelling_group = modelling_group,
+    disease = disease,
+    touchstone = touchstone,
     scenarios = c("rota-no-vaccination",
                   "rota-routine-default",
                   "rota-routine-ia2030_target"),
@@ -81,15 +106,28 @@ do_stochastics_2021 <- function(con, test_run) {
     allow_missing_disease = TRUE,
     bypass_cert_check = TRUE,
     lines = lines))
+  files <- data.frame(
+    touchstone = touchstone,
+    modelling_group = modelling_group,
+    disease = disease,
+    files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
+              paths$all_cal_file, paths$all_coh_file),
+    is_cohort = c(FALSE, TRUE, FALSE, TRUE),
+    is_under5 = c(TRUE, TRUE, FALSE, FALSE)
+  )
+  write.csv(files, output_files, append = TRUE, row.names = FALSE)
 
   #############################################################################
 
   stub <- "Allison Portnoy - stochastic-burden-est."
-  continue_on_error(stone_stochastic_process(
+  modelling_group = "Harvard-Sweet"
+  disease = "HPV"
+  touchstone = "202110gavi-3"
+  continue_on_error(paths <- stone_stochastic_process(
     con,
-    modelling_group = "Harvard-Sweet",
-    disease = "HPV",
-    touchstone = "202110gavi-3",
+    modelling_group = modelling_group,
+    disease = disease,
+    touchstone = touchstone,
     scenarios = c("hpv-no-vaccination",
                   "hpv-campaign-default",
                   "hpv-campaign-ia2030_target",
@@ -110,15 +148,28 @@ do_stochastics_2021 <- function(con, test_run) {
     runid_from_file = TRUE,
     bypass_cert_check = TRUE,
     lines = lines))
+  files <- data.frame(
+    touchstone = touchstone,
+    modelling_group = modelling_group,
+    disease = disease,
+    files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
+              paths$all_cal_file, paths$all_coh_file),
+    is_cohort = c(FALSE, TRUE, FALSE, TRUE),
+    is_under5 = c(TRUE, TRUE, FALSE, FALSE)
+  )
+  write.csv(files, output_files, append = TRUE, row.names = FALSE)
 
    #############################################################################
 
   stub <- "Keith Fraser - stochastic-burden-estimates.202110gavi-3_YF_IC-Garske_"
-  continue_on_error(stone_stochastic_process(
+  modelling_group = "IC-Garske"
+  disease = "YF"
+  touchstone = "202110gavi-3"
+  continue_on_error(paths <- stone_stochastic_process(
     con,
-    modelling_group = "IC-Garske",
-    disease = "YF",
-    touchstone = "202110gavi-3",
+    modelling_group = modelling_group,
+    disease = disease,
+    touchstone = touchstone,
     scenarios = c("yf-no-vaccination",
                   "yf-preventive-default",
                   "yf-preventive-ia2030_target",
@@ -134,14 +185,27 @@ do_stochastics_2021 <- function(con, test_run) {
     log_file = log_file,
     bypass_cert_check = TRUE,
     lines = lines))
+  files <- data.frame(
+    touchstone = touchstone,
+    modelling_group = modelling_group,
+    disease = disease,
+    files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
+              paths$all_cal_file, paths$all_coh_file),
+    is_cohort = c(FALSE, TRUE, FALSE, TRUE),
+    is_under5 = c(TRUE, TRUE, FALSE, FALSE)
+  )
+  write.csv(files, output_files, append = TRUE, row.names = FALSE)
 
   #############################################################################
 
-  continue_on_error(stone_stochastic_process(
+  modelling_group = "IVI-Kim"
+  disease = "Typhoid"
+  touchstone = "202110gavi-3"
+  continue_on_error(paths <- stone_stochastic_process(
     con,
-    modelling_group = "IVI-Kim",
-    disease = "Typhoid",
-    touchstone = "202110gavi-3",
+    modelling_group = modelling_group,
+    disease = disease,
+    touchstone = touchstone,
     scenarios = c("typhoid-no-vaccination",
                   "typhoid-campaign-default", "typhoid-campaign-ia2030_target",
                   "typhoid-routine-default",  "typhoid-routine-ia2030_target"),
@@ -159,15 +223,28 @@ do_stochastics_2021 <- function(con, test_run) {
     log_file = log_file,
     bypass_cert_check = TRUE,
     lines = lines))
+  files <- data.frame(
+    touchstone = touchstone,
+    modelling_group = modelling_group,
+    disease = disease,
+    files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
+              paths$all_cal_file, paths$all_coh_file),
+    is_cohort = c(FALSE, TRUE, FALSE, TRUE),
+    is_under5 = c(TRUE, TRUE, FALSE, FALSE)
+  )
+  write.csv(files, output_files, append = TRUE, row.names = FALSE)
 
   #####################################################
 
   stub <- "stochastic_burden_est_HepB-IC-Hallett_"
-  continue_on_error(stone_stochastic_process(
+  modelling_group = "IC-Hallett"
+  disease = "HepB"
+  touchstone = "202110gavi-3"
+  continue_on_error(paths <- stone_stochastic_process(
     con,
-    modelling_group = "IC-Hallett",
-    disease = "HepB",
-    touchstone = "202110gavi-3",
+    modelling_group = modelling_group,
+    disease = disease,
+    touchstone = touchstone,
     scenarios = c("hepb-bd-default-hepb-routine-default",
                   "hepb-bd-routine-default",
                   "hepb-bd-routine-ia2030_target-hepb-routine-ia2030_target",
@@ -188,14 +265,27 @@ do_stochastics_2021 <- function(con, test_run) {
               "hepb_cases_hcc_no_cirrh"),
     dalys = "dalys",
     lines = lines))
+  files <- data.frame(
+    touchstone = touchstone,
+    modelling_group = modelling_group,
+    disease = disease,
+    files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
+              paths$all_cal_file, paths$all_coh_file),
+    is_cohort = c(FALSE, TRUE, FALSE, TRUE),
+    is_under5 = c(TRUE, TRUE, FALSE, FALSE)
+  )
+  write.csv(files, output_files, append = TRUE, row.names = FALSE)
 
   #############################################################################
 
-  continue_on_error(stone_stochastic_process(
+  modelling_group = "IVI-Kim"
+  disease = "Cholera"
+  touchstone = "202110gavi-3"
+  continue_on_error(paths <- stone_stochastic_process(
     con,
-    modelling_group = "IVI-Kim",
-    disease = "Cholera",
-    touchstone = "202110gavi-3",
+    modelling_group = modelling_group,
+    disease = disease,
+    touchstone = touchstone,
     scenarios = c("cholera-no-vaccination", "cholera-campaign-default"),
     in_path = file.path(in_path, "IVI-Kim-Cholera"),
     files = c("Jong-Hoon Kim - stoch_Cholera_novacc_20211221T00.csv.xz",
@@ -208,14 +298,27 @@ do_stochastics_2021 <- function(con, test_run) {
     log_file = log_file,
     bypass_cert_check = TRUE,
     lines = lines))
+  files <- data.frame(
+    touchstone = touchstone,
+    modelling_group = modelling_group,
+    disease = disease,
+    files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
+              paths$all_cal_file, paths$all_coh_file),
+    is_cohort = c(FALSE, TRUE, FALSE, TRUE),
+    is_under5 = c(TRUE, TRUE, FALSE, FALSE)
+  )
+  write.csv(files, output_files, append = TRUE, row.names = FALSE)
 
   #############################################################################
 
-  continue_on_error(stone_stochastic_process(
+  modelling_group = "JHU-Lee"
+  disease = "Cholera"
+  touchstone = "202110gavi-3"
+  continue_on_error(paths <- stone_stochastic_process(
     con,
-    modelling_group = "JHU-Lee",
-    disease = "Cholera",
-    touchstone = "202110gavi-3",
+    modelling_group = modelling_group,
+    disease = disease,
+    touchstone = touchstone,
     scenarios = c("cholera-no-vaccination", "cholera-campaign-default"),
     in_path = file.path(in_path, "JHU-Lee-Cholera"),
     files = c("Kaiyue Zou - no-vaccination.csv.xz",
@@ -228,16 +331,29 @@ do_stochastics_2021 <- function(con, test_run) {
     log_file = log_file,
     bypass_cert_check = TRUE,
     lines = lines))
+  files <- data.frame(
+    touchstone = touchstone,
+    modelling_group = modelling_group,
+    disease = disease,
+    files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
+              paths$all_cal_file, paths$all_coh_file),
+    is_cohort = c(FALSE, TRUE, FALSE, TRUE),
+    is_under5 = c(TRUE, TRUE, FALSE, FALSE)
+  )
+  write.csv(files, output_files, append = TRUE, row.names = FALSE)
 
   #############################################################################
 
 
   stub <- "Amy Winter - stochastic_burden_est-rubella-"
-  continue_on_error(stone_stochastic_process(
+  modelling_group = "JHU-Lessler"
+  disease = "Rubella"
+  touchstone = "202110gavi-3"
+  continue_on_error(paths <- stone_stochastic_process(
     con,
-    modelling_group = "JHU-Lessler",
-    disease = "Rubella",
-    touchstone = "202110gavi-3",
+    modelling_group = modelling_group,
+    disease = disease,
+    touchstone = touchstone,
     scenarios = c("rubella-routine-no-vaccination",
                   "rubella-campaign-default",
                   "rubella-rcv1-default",
@@ -268,6 +384,16 @@ do_stochastics_2021 <- function(con, test_run) {
     dalys = "dalys",
     bypass_cert_check = TRUE,
     lines = lines))
+  files <- data.frame(
+    touchstone = touchstone,
+    modelling_group = modelling_group,
+    disease = disease,
+    files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
+              paths$all_cal_file, paths$all_coh_file),
+    is_cohort = c(FALSE, TRUE, FALSE, TRUE),
+    is_under5 = c(TRUE, TRUE, FALSE, FALSE)
+  )
+  write.csv(files, output_files, append = TRUE, row.names = FALSE)
 
   #############################################################################
 
@@ -283,11 +409,14 @@ do_stochastics_2021 <- function(con, test_run) {
                      "hib-routine-default-LiST",
                      "hib-routine-ia2030_target-LiST")
 
-  continue_on_error(stone_stochastic_process(
+  modelling_group = "JHU-Tam"
+  disease = "Hib"
+  touchstone = "202110gavi-3"
+  continue_on_error(paths <- stone_stochastic_process(
     con,
-    modelling_group = "JHU-Tam",
-    disease = "Hib",
-    touchstone = "202110gavi-3",
+    modelling_group = modelling_group,
+    disease = disease,
+    touchstone = touchstone,
     scenarios = hib_scenarios,
     in_path = file.path(in_path),
     files = ":scenario.csv.xz",
@@ -302,6 +431,16 @@ do_stochastics_2021 <- function(con, test_run) {
     dalys = list_params_hib_pcv,
     bypass_cert_check = TRUE,
     lines = lines))
+  files <- data.frame(
+    touchstone = touchstone,
+    modelling_group = modelling_group,
+    disease = disease,
+    files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
+              paths$all_cal_file, paths$all_coh_file),
+    is_cohort = c(FALSE, TRUE, FALSE, TRUE),
+    is_under5 = c(TRUE, TRUE, FALSE, FALSE)
+  )
+  write.csv(files, output_files, append = TRUE, row.names = FALSE)
 
   # And to sort out DALYs on the centrals:
 
@@ -316,11 +455,14 @@ do_stochastics_2021 <- function(con, test_run) {
                      "pcv-routine-default-LiST",
                      "pcv-routine-ia2030_target-LiST")
 
-  continue_on_error(stone_stochastic_process(
+  modelling_group = "JHU-Tam"
+  disease = "PCV"
+  touchstone = "202110gavi-3"
+  continue_on_error(paths <- stone_stochastic_process(
     con,
-    modelling_group = "JHU-Tam",
-    disease = "PCV",
-    touchstone = "202110gavi-3",
+    modelling_group = modelling_group,
+    disease = disease,
+    touchstone = touchstone,
     scenarios = pcv_scenarios,
     in_path = file.path(in_path),
     files = ":scenario.csv.xz",
@@ -335,6 +477,16 @@ do_stochastics_2021 <- function(con, test_run) {
     dalys = list_params_hib_pcv,
     bypass_cert_check = TRUE,
     lines = lines))
+  files <- data.frame(
+    touchstone = touchstone,
+    modelling_group = modelling_group,
+    disease = disease,
+    files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
+              paths$all_cal_file, paths$all_coh_file),
+    is_cohort = c(FALSE, TRUE, FALSE, TRUE),
+    is_under5 = c(TRUE, TRUE, FALSE, FALSE)
+  )
+  write.csv(files, output_files, append = TRUE, row.names = FALSE)
 
   # And to sort out DALYs on the centrals:
 
@@ -357,11 +509,14 @@ do_stochastics_2021 <- function(con, test_run) {
                       "rota-routine-default-LiST",
                       "rota-routine-ia2030_target-LiST")
 
-  continue_on_error(stone_stochastic_process(
+  modelling_group = "JHU-Tam"
+  disease = "Rota"
+  touchstone = "202110gavi-3"
+  continue_on_error(paths <- stone_stochastic_process(
     con,
-    modelling_group = "JHU-Tam",
-    disease = "Rota",
-    touchstone = "202110gavi-3",
+    modelling_group = modelling_group,
+    disease = disease,
+    touchstone = touchstone,
     scenarios = rota_scenarios,
     in_path = file.path(in_path),
     files = ":scenario.csv.xz",
@@ -374,6 +529,16 @@ do_stochastics_2021 <- function(con, test_run) {
     dalys = list_params_rota,
     bypass_cert_check = TRUE,
     lines = lines))
+  files <- data.frame(
+    touchstone = touchstone,
+    modelling_group = modelling_group,
+    disease = disease,
+    files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
+              paths$all_cal_file, paths$all_coh_file),
+    is_cohort = c(FALSE, TRUE, FALSE, TRUE),
+    is_under5 = c(TRUE, TRUE, FALSE, FALSE)
+  )
+  write.csv(files, output_files, append = TRUE, row.names = FALSE)
 
 
   # And to sort out DALYs on the centrals:
@@ -388,11 +553,14 @@ do_stochastics_2021 <- function(con, test_run) {
   ####################################################################################
 
   stub <- "Eric Johnson - "
-  continue_on_error(stone_stochastic_process(
+  modelling_group = "KPW-Jackson"
+  disease = "MenA"
+  touchstone = "202110gavi-3"
+  continue_on_error(paths <- stone_stochastic_process(
     con,
-    modelling_group = "KPW-Jackson",
-    disease = "MenA",
-    touchstone = "202110gavi-3",
+    modelling_group = modelling_group,
+    disease = disease,
+    touchstone = touchstone,
     scenarios = c("mena-booster-default",
                   "mena-campaign-default",
                   "mena-campaign-ia2030_target",
@@ -409,14 +577,27 @@ do_stochastics_2021 <- function(con, test_run) {
     log_file = log_file,
     bypass_cert_check = TRUE,
     lines = lines))
+  files <- data.frame(
+    touchstone = touchstone,
+    modelling_group = modelling_group,
+    disease = disease,
+    files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
+              paths$all_cal_file, paths$all_coh_file),
+    is_cohort = c(FALSE, TRUE, FALSE, TRUE),
+    is_under5 = c(TRUE, TRUE, FALSE, FALSE)
+  )
+  write.csv(files, output_files, append = TRUE, row.names = FALSE)
 
   #############################################################################
 
-  continue_on_error(stone_stochastic_process(
+  modelling_group = "Li"
+  disease = "HepB"
+  touchstone = "202110gavi-2"
+  continue_on_error(paths <- stone_stochastic_process(
     con,
-    modelling_group = "Li",
-    disease = "HepB",
-    touchstone = "202110gavi-2",
+    modelling_group = modelling_group,
+    disease = disease,
+    touchstone = touchstone,
     scenarios = c("hepb-bd-default-hepb-routine-default",
                   "hepb-bd-routine-default",
                   "hepb-bd-routine-ia2030_target-hepb-routine-ia2030_target",
@@ -438,15 +619,28 @@ do_stochastics_2021 <- function(con, test_run) {
               "hepb_cases_chronic", "hepb_chronic_symptomatic_in_acute_phase"),
     dalys = "dalys",
     lines = lines))
+  files <- data.frame(
+    touchstone = touchstone,
+    modelling_group = modelling_group,
+    disease = disease,
+    files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
+              paths$all_cal_file, paths$all_coh_file),
+    is_cohort = c(FALSE, TRUE, FALSE, TRUE),
+    is_under5 = c(TRUE, TRUE, FALSE, FALSE)
+  )
+  write.csv(files, output_files, append = TRUE, row.names = FALSE)
 
   #############################################################################
 
   stub <- "Kaja Abbas - PSA_202110gavi-3_"
-  continue_on_error(stone_stochastic_process(
+  modelling_group = "LSHTM-Clark"
+  disease = "Hib"
+  touchstone = "202110gavi-3"
+  continue_on_error(paths <- stone_stochastic_process(
     con,
-    modelling_group = "LSHTM-Clark",
-    disease = "Hib",
-    touchstone = "202110gavi-3",
+    modelling_group = modelling_group,
+    disease = disease,
+    touchstone = touchstone,
     scenarios = c("hib-no-vaccination","hib-routine-default","hib-routine-ia2030_target"),
     in_path = file.path(in_path, "LSHTM-Clark_Hib"),
     files = c(paste0(stub, ":scenario.csv.xz")),
@@ -457,16 +651,29 @@ do_stochastics_2021 <- function(con, test_run) {
     pre_aggregation_path = pre_aggregation_path,
     log_file = log_file,
     lines = lines))
+  files <- data.frame(
+    touchstone = touchstone,
+    modelling_group = modelling_group,
+    disease = disease,
+    files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
+              paths$all_cal_file, paths$all_coh_file),
+    is_cohort = c(FALSE, TRUE, FALSE, TRUE),
+    is_under5 = c(TRUE, TRUE, FALSE, FALSE)
+  )
+  write.csv(files, output_files, append = TRUE, row.names = FALSE)
 
   #############################################################################
 
 
   stub <- "Kaja Abbas - PSA_202110gavi-3_"
-  continue_on_error(stone_stochastic_process(
+  modelling_group = "LSHTM-Clark"
+  disease = "Rota"
+  touchstone = "202110gavi-3"
+  continue_on_error(paths <- stone_stochastic_process(
     con,
-    modelling_group = "LSHTM-Clark",
-    disease = "Rota",
-    touchstone = "202110gavi-3",
+    modelling_group = modelling_group,
+    disease = disease,
+    touchstone = touchstone,
     scenarios = c("rota-no-vaccination","rota-routine-default","rota-routine-ia2030_target"),
     in_path = file.path(in_path, "LSHTM-Clark_Rota"),
     files = c(paste0(stub, ":scenario.csv.xz")),
@@ -477,16 +684,29 @@ do_stochastics_2021 <- function(con, test_run) {
     pre_aggregation_path = pre_aggregation_path,
     log_file = log_file,
     lines = lines))
+  files <- data.frame(
+    touchstone = touchstone,
+    modelling_group = modelling_group,
+    disease = disease,
+    files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
+              paths$all_cal_file, paths$all_coh_file),
+    is_cohort = c(FALSE, TRUE, FALSE, TRUE),
+    is_under5 = c(TRUE, TRUE, FALSE, FALSE)
+  )
+  write.csv(files, output_files, append = TRUE, row.names = FALSE)
 
   #############################################################################
 
 
   stub <- "stochastic-burden-"
-  continue_on_error(stone_stochastic_process(
+  modelling_group = "LSHTM-Jit"
+  disease = "HPV"
+  touchstone = "202110gavi-3"
+  continue_on_error(paths <- stone_stochastic_process(
     con,
-    modelling_group = "LSHTM-Jit",
-    disease = "HPV",
-    touchstone = "202110gavi-3",
+    modelling_group = modelling_group,
+    disease = disease,
+    touchstone = touchstone,
     scenarios = c("hpv-no-vaccination",
                   "hpv-campaign-default",
                   "hpv-routine-default",
@@ -503,15 +723,28 @@ do_stochastics_2021 <- function(con, test_run) {
     log_file = log_file,
     bypass_cert_check = TRUE,
     lines = lines))
+  files <- data.frame(
+    touchstone = touchstone,
+    modelling_group = modelling_group,
+    disease = disease,
+    files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
+              paths$all_cal_file, paths$all_coh_file),
+    is_cohort = c(FALSE, TRUE, FALSE, TRUE),
+    is_under5 = c(TRUE, TRUE, FALSE, FALSE)
+  )
+  write.csv(files, output_files, append = TRUE, row.names = FALSE)
 
   #############################################################################
 
   stub <- "Han Fu - stochastic_burden_estimate_measles-LSHTM-Jit-"
-  continue_on_error(stone_stochastic_process(
+  modelling_group = "LSHTM-Jit"
+  disease = "Measles"
+  touchstone = "202110gavi-2"
+  continue_on_error(paths <- stone_stochastic_process(
     con,
-    modelling_group = "LSHTM-Jit",
-    disease = "Measles",
-    touchstone = "202110gavi-2",
+    modelling_group = modelling_group,
+    disease = disease,
+    touchstone = touchstone,
     scenarios = c("measles-no-vaccination",
                   "measles-campaign-default",
                   "measles-campaign-only-default",
@@ -538,15 +771,28 @@ do_stochastics_2021 <- function(con, test_run) {
     pre_aggregation_path = pre_aggregation_path,
     log_file = log_file,
     lines = lines))
+  files <- data.frame(
+    touchstone = touchstone,
+    modelling_group = modelling_group,
+    disease = disease,
+    files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
+              paths$all_cal_file, paths$all_coh_file),
+    is_cohort = c(FALSE, TRUE, FALSE, TRUE),
+    is_under5 = c(TRUE, TRUE, FALSE, FALSE)
+  )
+  write.csv(files, output_files, append = TRUE, row.names = FALSE)
 
   #############################################################################
 
   stub <- "stochastic_burden_est_"
-  continue_on_error(stone_stochastic_process(
+  modelling_group = "NUS-Chen"
+  disease = "PCV"
+  touchstone = "202110gavi-3"
+  continue_on_error(paths <- stone_stochastic_process(
     con,
-    modelling_group = "NUS-Chen",
-    disease = "PCV",
-    touchstone = "202110gavi-3",
+    modelling_group = modelling_group,
+    disease = disease,
+    touchstone = touchstone,
     scenarios = c("pcv-no-vaccination","pcv-routine-default","pcv-routine-ia2030_target"),
     in_path = file.path(in_path, "LSHTM-NUS-Chen_PCV"),
     files = paste0(stub, ":scenario.csv.xz"),
@@ -557,14 +803,27 @@ do_stochastics_2021 <- function(con, test_run) {
     pre_aggregation_path = pre_aggregation_path,
     log_file = log_file,
     lines = lines))
+  files <- data.frame(
+    touchstone = touchstone,
+    modelling_group = modelling_group,
+    disease = disease,
+    files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
+              paths$all_cal_file, paths$all_coh_file),
+    is_cohort = c(FALSE, TRUE, FALSE, TRUE),
+    is_under5 = c(TRUE, TRUE, FALSE, FALSE)
+  )
+  write.csv(files, output_files, append = TRUE, row.names = FALSE)
 
+  #############################################################################
 
-
-  continue_on_error(stone_stochastic_process(
+  modelling_group = "PHE-Vynnycky"
+  disease = "Rubella"
+  touchstone = "202110gavi-3"
+  continue_on_error(paths <- stone_stochastic_process(
     con,
-    modelling_group = "PHE-Vynnycky",
-    disease = "Rubella",
-    touchstone = "202110gavi-3",
+    modelling_group = modelling_group,
+    disease = disease,
+    touchstone = touchstone,
     scenarios = c("rubella-routine-no-vaccination",
                   "rubella-campaign-default",
                   "rubella-rcv1-default",
@@ -595,15 +854,28 @@ do_stochastics_2021 <- function(con, test_run) {
     dalys = "dalys",
     bypass_cert_check = TRUE,
     lines = lines))
+  files <- data.frame(
+    touchstone = touchstone,
+    modelling_group = modelling_group,
+    disease = disease,
+    files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
+              paths$all_cal_file, paths$all_coh_file),
+    is_cohort = c(FALSE, TRUE, FALSE, TRUE),
+    is_under5 = c(TRUE, TRUE, FALSE, FALSE)
+  )
+  write.csv(files, output_files, append = TRUE, row.names = FALSE)
 
   #############################################################################
 
   stub <- "Sean Moore - stochastic_burden_est_JE_UND-Moore_"
-  continue_on_error(stone_stochastic_process(
+  modelling_group = "UND-Moore"
+  disease = "JE"
+  touchstone = "202110gavi-2"
+  continue_on_error(paths <- stone_stochastic_process(
     con,
-    modelling_group = "UND-Moore",
-    disease = "JE",
-    touchstone = "202110gavi-2",
+    modelling_group = modelling_group,
+    disease = disease,
+    touchstone = touchstone,
     scenarios = c("je-routine-no-vaccination",
                   "je-campaign-default",
                   "je-routine-default",
@@ -619,13 +891,30 @@ do_stochastics_2021 <- function(con, test_run) {
     pre_aggregation_path = pre_aggregation_path,
     log_file = log_file,
     lines = lines))
+  files <- data.frame(
+    touchstone = touchstone,
+    modelling_group = modelling_group,
+    disease = disease,
+    files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
+              paths$all_cal_file, paths$all_coh_file),
+    is_cohort = c(FALSE, TRUE, FALSE, TRUE),
+    is_under5 = c(TRUE, TRUE, FALSE, FALSE)
+  )
+  write.csv(files, output_files, append = TRUE, row.names = FALSE)
+
+
+  #############################################################################
+
 
   stub <- "stochastic_burden_est_YF_UND-Perkins_"
-  continue_on_error(stone_stochastic_process(
+  modelling_group = "UND-Perkins"
+  disease = "YF"
+  touchstone = "202110gavi-3"
+  continue_on_error(paths <- stone_stochastic_process(
     con,
-    modelling_group = "UND-Perkins",
-    disease = "YF",
-    touchstone = "202110gavi-3",
+    modelling_group = modelling_group,
+    disease = disease,
+    touchstone = touchstone,
     scenarios = c("yf-no-vaccination",
                   "yf-preventive-default",
                   "yf-preventive-ia2030_target",
@@ -641,13 +930,30 @@ do_stochastics_2021 <- function(con, test_run) {
     log_file = log_file,
     bypass_cert_check = TRUE,
     lines = lines))
+  files <- data.frame(
+    touchstone = touchstone,
+    modelling_group = modelling_group,
+    disease = disease,
+    files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
+              paths$all_cal_file, paths$all_coh_file),
+    is_cohort = c(FALSE, TRUE, FALSE, TRUE),
+    is_under5 = c(TRUE, TRUE, FALSE, FALSE)
+  )
+  write.csv(files, output_files, append = TRUE, row.names = FALSE)
+
+
+  #############################################################################
+
 
   stub <- "Holly Burrows - stochastic_burden_est_TF-Yale-Burrows"
-  continue_on_error(stone_stochastic_process(
+  modelling_group = "Yale-Pitzer"
+  disease = "Typhoid"
+  touchstone = "202110gavi-3"
+  continue_on_error(paths <- stone_stochastic_process(
     con,
-    modelling_group = "Yale-Pitzer",
-    disease = "Typhoid",
-    touchstone = "202110gavi-3",
+    modelling_group = modelling_group,
+    disease = disease,
+    touchstone = touchstone,
     scenarios = c("typhoid-no-vaccination",
                   "typhoid-campaign-default", "typhoid-campaign-ia2030_target",
                   "typhoid-routine-default",  "typhoid-routine-ia2030_target"),
@@ -665,6 +971,16 @@ do_stochastics_2021 <- function(con, test_run) {
     log_file = log_file,
     bypass_cert_check = TRUE,
     lines = lines))
+  files <- data.frame(
+    touchstone = touchstone,
+    modelling_group = modelling_group,
+    disease = disease,
+    files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
+              paths$all_cal_file, paths$all_coh_file),
+    is_cohort = c(FALSE, TRUE, FALSE, TRUE),
+    is_under5 = c(TRUE, TRUE, FALSE, FALSE)
+  )
+  write.csv(files, output_files, append = TRUE, row.names = FALSE)
 }
 
 do_stochastics_2019 <- function(con, test_run) {

--- a/scripts/run_stochastic_process.R
+++ b/scripts/run_stochastic_process.R
@@ -541,6 +541,7 @@ do_stochastics_2021 <- function(con, test_run) {
   )
 
   rota_scenarios <- c("rota-no-vaccination-LiST",
+                      "rota-routine-default-LiST",
                       "rota-routine-ia2030_target-LiST")
 
   modelling_group = "JHU-Tam"

--- a/scripts/run_stochastic_process.R
+++ b/scripts/run_stochastic_process.R
@@ -43,9 +43,9 @@ do_stochastics_2021 <- function(con, test_run, in_path, out_path) {
   }
 
   stub <- "Andromachi Karachaliou - stochastic-burden.202110gavi-2.MenA_Cambridge-Trotter_"
-  modelling_group = "Cambridge-Trotter"
-  disease = "MenA"
-  touchstone = "202110gavi-3"
+  modelling_group <- "Cambridge-Trotter"
+  disease <- "MenA"
+  touchstone <- "202110gavi-3"
   continue_on_error({
     paths <- stone_stochastic_process(
       con,
@@ -86,9 +86,9 @@ do_stochastics_2021 <- function(con, test_run, in_path, out_path) {
   #############################################################################
 
   stub <- "Aniruddha Deshpande - stochastic_burden_est_lopman_"
-  modelling_group = "Emory-Lopman"
-  disease = "Rota"
-  touchstone = "202110gavi-3"
+  modelling_group <- "Emory-Lopman"
+  disease <- "Rota"
+  touchstone <- "202110gavi-3"
   continue_on_error({
     paths <- stone_stochastic_process(
       con,
@@ -127,9 +127,9 @@ do_stochastics_2021 <- function(con, test_run, in_path, out_path) {
   #############################################################################
 
   stub <- "Allison Portnoy - stochastic-burden-est."
-  modelling_group = "Harvard-Sweet"
-  disease = "HPV"
-  touchstone = "202110gavi-3"
+  modelling_group <- "Harvard-Sweet"
+  disease <- "HPV"
+  touchstone <- "202110gavi-3"
   continue_on_error({
     paths <- stone_stochastic_process(
       con,
@@ -172,9 +172,9 @@ do_stochastics_2021 <- function(con, test_run, in_path, out_path) {
   #############################################################################
 
   stub <- "Keith Fraser - stochastic-burden-estimates.202110gavi-3_YF_IC-Garske_"
-  modelling_group = "IC-Garske"
-  disease = "YF"
-  touchstone = "202110gavi-3"
+  modelling_group <- "IC-Garske"
+  disease <- "YF"
+  touchstone <- "202110gavi-3"
   continue_on_error({
     paths <- stone_stochastic_process(
       con,
@@ -211,9 +211,9 @@ do_stochastics_2021 <- function(con, test_run, in_path, out_path) {
 
   #############################################################################
 
-  modelling_group = "IVI-Kim"
-  disease = "Typhoid"
-  touchstone = "202110gavi-3"
+  modelling_group <- "IVI-Kim"
+  disease <- "Typhoid"
+  touchstone <- "202110gavi-3"
   continue_on_error({
     paths <- stone_stochastic_process(
       con,
@@ -253,9 +253,9 @@ do_stochastics_2021 <- function(con, test_run, in_path, out_path) {
   #####################################################
 
   stub <- "stochastic_burden_est_HepB-IC-Hallett_"
-  modelling_group = "IC-Hallett"
-  disease = "HepB"
-  touchstone = "202110gavi-3"
+  modelling_group <- "IC-Hallett"
+  disease <- "HepB"
+  touchstone <- "202110gavi-3"
   continue_on_error({
     paths <- stone_stochastic_process(
       con,
@@ -297,9 +297,9 @@ do_stochastics_2021 <- function(con, test_run, in_path, out_path) {
 
   #############################################################################
 
-  modelling_group = "IVI-Kim"
-  disease = "Cholera"
-  touchstone = "202110gavi-3"
+  modelling_group <- "IVI-Kim"
+  disease <- "Cholera"
+  touchstone <- "202110gavi-3"
   continue_on_error({
     paths <- stone_stochastic_process(
       con,
@@ -333,9 +333,9 @@ do_stochastics_2021 <- function(con, test_run, in_path, out_path) {
 
   #############################################################################
 
-  modelling_group = "JHU-Lee"
-  disease = "Cholera"
-  touchstone = "202110gavi-3"
+  modelling_group <- "JHU-Lee"
+  disease <- "Cholera"
+  touchstone <- "202110gavi-3"
   continue_on_error({
     paths <- stone_stochastic_process(
       con,
@@ -371,9 +371,9 @@ do_stochastics_2021 <- function(con, test_run, in_path, out_path) {
 
 
   stub <- "Amy Winter - stochastic_burden_est-rubella-"
-  modelling_group = "JHU-Lessler"
-  disease = "Rubella"
-  touchstone = "202110gavi-3"
+  modelling_group <- "JHU-Lessler"
+  disease <- "Rubella"
+  touchstone <- "202110gavi-3"
   continue_on_error({
     paths <- stone_stochastic_process(
       con,
@@ -437,9 +437,9 @@ do_stochastics_2021 <- function(con, test_run, in_path, out_path) {
                      "hib-routine-default-LiST",
                      "hib-routine-ia2030_target-LiST")
 
-  modelling_group = "JHU-Tam"
-  disease = "Hib"
-  touchstone = "202110gavi-3"
+  modelling_group <- "JHU-Tam"
+  disease <- "Hib"
+  touchstone <- "202110gavi-3"
   continue_on_error({
     paths <- stone_stochastic_process(
       con,
@@ -487,9 +487,9 @@ do_stochastics_2021 <- function(con, test_run, in_path, out_path) {
                      "pcv-routine-default-LiST",
                      "pcv-routine-ia2030_target-LiST")
 
-  modelling_group = "JHU-Tam"
-  disease = "PCV"
-  touchstone = "202110gavi-3"
+  modelling_group <- "JHU-Tam"
+  disease <- "PCV"
+  touchstone <- "202110gavi-3"
   continue_on_error({
     paths <- stone_stochastic_process(
       con,
@@ -545,9 +545,9 @@ do_stochastics_2021 <- function(con, test_run, in_path, out_path) {
                       "rota-routine-default-LiST",
                       "rota-routine-ia2030_target-LiST")
 
-  modelling_group = "JHU-Tam"
-  disease = "Rota"
-  touchstone = "202110gavi-3"
+  modelling_group <- "JHU-Tam"
+  disease <- "Rota"
+  touchstone <- "202110gavi-3"
   continue_on_error({
     paths <- stone_stochastic_process(
       con,
@@ -594,9 +594,9 @@ do_stochastics_2021 <- function(con, test_run, in_path, out_path) {
 
 
   stub <- "stochastic_burden_est_MenA_KPWA_"
-  modelling_group = "KPW-Jackson"
-  disease = "MenA"
-  touchstone = "202110gavi-3"
+  modelling_group <- "KPW-Jackson"
+  disease <- "MenA"
+  touchstone <- "202110gavi-3"
   continue_on_error({
     paths <- stone_stochastic_process(
       con,
@@ -639,9 +639,9 @@ do_stochastics_2021 <- function(con, test_run, in_path, out_path) {
 
   #############################################################################
 
-  modelling_group = "Li"
-  disease = "HepB"
-  touchstone = "202110gavi-2"
+  modelling_group <- "Li"
+  disease <- "HepB"
+  touchstone <- "202110gavi-2"
   continue_on_error({
     paths <- stone_stochastic_process(
       con,
@@ -685,9 +685,9 @@ do_stochastics_2021 <- function(con, test_run, in_path, out_path) {
   #############################################################################
 
   stub <- "Kaja Abbas - PSA_202110gavi-3_"
-  modelling_group = "LSHTM-Clark"
-  disease = "Hib"
-  touchstone = "202110gavi-3"
+  modelling_group <- "LSHTM-Clark"
+  disease <- "Hib"
+  touchstone <- "202110gavi-3"
   continue_on_error({
     paths <- stone_stochastic_process(
       con,
@@ -721,9 +721,9 @@ do_stochastics_2021 <- function(con, test_run, in_path, out_path) {
 
 
   stub <- "Kaja Abbas - PSA_202110gavi-3_"
-  modelling_group = "LSHTM-Clark"
-  disease = "Rota"
-  touchstone = "202110gavi-3"
+  modelling_group <- "LSHTM-Clark"
+  disease <- "Rota"
+  touchstone <- "202110gavi-3"
   continue_on_error({
     paths <- stone_stochastic_process(
       con,
@@ -757,9 +757,9 @@ do_stochastics_2021 <- function(con, test_run, in_path, out_path) {
 
 
   stub <- "stochastic-burden-"
-  modelling_group = "LSHTM-Jit"
-  disease = "HPV"
-  touchstone = "202110gavi-3"
+  modelling_group <- "LSHTM-Jit"
+  disease <- "HPV"
+  touchstone <- "202110gavi-3"
   continue_on_error({
     paths <- stone_stochastic_process(
       con,
@@ -801,9 +801,9 @@ do_stochastics_2021 <- function(con, test_run, in_path, out_path) {
   #############################################################################
 
   stub <- "Han Fu - stochastic_burden_estimate_measles-LSHTM-Jit-"
-  modelling_group = "LSHTM-Jit"
-  disease = "Measles"
-  touchstone = "202110gavi-3"
+  modelling_group <- "LSHTM-Jit"
+  disease <- "Measles"
+  touchstone <- "202110gavi-3"
   continue_on_error({
     paths <- stone_stochastic_process(
       con,
@@ -852,9 +852,9 @@ do_stochastics_2021 <- function(con, test_run, in_path, out_path) {
   #############################################################################
 
   stub <- "stochastic_burden_est_"
-  modelling_group = "NUS-Chen"
-  disease = "PCV"
-  touchstone = "202110gavi-3"
+  modelling_group <- "NUS-Chen"
+  disease <- "PCV"
+  touchstone <- "202110gavi-3"
   continue_on_error({
     paths <- stone_stochastic_process(
       con,
@@ -886,9 +886,9 @@ do_stochastics_2021 <- function(con, test_run, in_path, out_path) {
 
   #############################################################################
 
-  modelling_group = "PHE-Vynnycky"
-  disease = "Rubella"
-  touchstone = "202110gavi-3"
+  modelling_group <- "PHE-Vynnycky"
+  disease <- "Rubella"
+  touchstone <- "202110gavi-3"
   continue_on_error({
     paths <- stone_stochastic_process(
       con,
@@ -941,9 +941,9 @@ do_stochastics_2021 <- function(con, test_run, in_path, out_path) {
   #############################################################################
 
   stub <- "coverage_202110gavi-3_"
-  modelling_group = "PSU-Ferrari"
-  disease = "Measles"
-  touchstone = "202110gavi-3"
+  modelling_group <- "PSU-Ferrari"
+  disease <- "Measles"
+  touchstone <- "202110gavi-3"
   continue_on_error({
     paths <- stone_stochastic_process(
       con,
@@ -985,9 +985,9 @@ do_stochastics_2021 <- function(con, test_run, in_path, out_path) {
   #############################################################################
 
   stub <- "Sean Moore - stochastic_burden_est_JE_UND-Moore_"
-  modelling_group = "UND-Moore"
-  disease = "JE"
-  touchstone = "202110gavi-2"
+  modelling_group <- "UND-Moore"
+  disease <- "JE"
+  touchstone <- "202110gavi-2"
   continue_on_error({
     paths <- stone_stochastic_process(
       con,
@@ -1027,9 +1027,9 @@ do_stochastics_2021 <- function(con, test_run, in_path, out_path) {
 
 
   stub <- "stochastic_burden_est_YF_UND-Perkins_"
-  modelling_group = "UND-Perkins"
-  disease = "YF"
-  touchstone = "202110gavi-3"
+  modelling_group <- "UND-Perkins"
+  disease <- "YF"
+  touchstone <- "202110gavi-3"
   continue_on_error({
     paths <- stone_stochastic_process(
       con,
@@ -1069,9 +1069,9 @@ do_stochastics_2021 <- function(con, test_run, in_path, out_path) {
 
 
   stub <- "Holly Burrows - stochastic_burden_est_TF-Yale-Burrows"
-  modelling_group = "Yale-Pitzer"
-  disease = "Typhoid"
-  touchstone = "202110gavi-3"
+  modelling_group <- "Yale-Pitzer"
+  disease <- "Typhoid"
+  touchstone <- "202110gavi-3"
   continue_on_error({
     paths <- stone_stochastic_process(
       con,

--- a/scripts/run_stochastic_process.R
+++ b/scripts/run_stochastic_process.R
@@ -22,10 +22,10 @@ continue_on_error <- function(expr) {
 
 do_stochastics_2021 <- function(con, test_run) {
   in_path <- "Z:/File requests/latest/202110gavi/"
-  out_path <- "Z:/stochastic_2021_output/aggregated/"
-  pre_aggregation_path <- "Z:/stochastic_2021_output/pre-aggregate/"
-  log_file <- "Z:/stochastic_2021_output/log.txt"
-  output_files <- "Z:/stochastic_2021_output/output_files.csv"
+  out_path <- "Z:/stochastic_2021_output_2/aggregated/"
+  pre_aggregation_path <- "Z:/stochastic_2021_output_2/pre-aggregate/"
+  log_file <- "Z:/stochastic_2021_output_2/log.txt"
+  output_files <- "Z:/stochastic_2021_output_2/output_files.csv"
   files <- data.frame(
     touchstone = character(0),
     modelling_group = character(0),
@@ -34,6 +34,8 @@ do_stochastics_2021 <- function(con, test_run) {
     is_cohort = logical(0),
     is_under5 = logical(0)
   )
+  dir.create(out_path, showWarnings = FALSE, recursive = TRUE)
+  dir.create(pre_aggregation_path, showWarnings = FALSE, recursive = TRUE)
   write.csv(files, output_files, row.names = FALSE)
 
   lines <- Inf
@@ -45,39 +47,42 @@ do_stochastics_2021 <- function(con, test_run) {
   modelling_group = "Cambridge-Trotter"
   disease = "MenA"
   touchstone = "202110gavi-3"
-  continue_on_error(paths <- stone_stochastic_process(
-    con,
-    modelling_group = modelling_group,
-    disease = disease,
-    touchstone = touchstone,
-    scenarios = c("mena-no-vaccination", "mena-campaign-default",
-                  "mena-routine-default", "mena-booster-default",
-                  "mena-campaign-ia2030_target", "mena-routine-ia2030_target"),
-    in_path = file.path(in_path, "Cambridge-Trotter"),
-    files = c(paste0(stub, "no_vaccination_:index.csv.xz"),
-              paste0(stub, "campaign_default_:index.csv.xz"),
-              paste0(stub, "routine_default_:index.csv.xz"),
-              paste0(stub, "booster_:index.csv.xz"),
-              paste0(stub, "campaign-ia2030_target_:index.csv.xz"),
-              paste0(stub, "routine-ia2030_target_:index.csv.xz")),
-    cert = "",
-    index_start = 1,
-    index_end = 26,
-    out_path = out_path,
-    pre_aggregation_path = pre_aggregation_path,
-    log_file = log_file,
-    bypass_cert_check = TRUE,
-    lines = lines))
-  files <- data.frame(
-    touchstone = touchstone,
-    modelling_group = modelling_group,
-    disease = disease,
-    files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
-              paths$all_cal_file, paths$all_coh_file),
-    is_cohort = c(FALSE, TRUE, FALSE, TRUE),
-    is_under5 = c(TRUE, TRUE, FALSE, FALSE)
-  )
-  write.csv(files, output_files, append = TRUE, row.names = FALSE)
+  continue_on_error({
+    paths <- stone_stochastic_process(
+      con,
+      modelling_group = modelling_group,
+      disease = disease,
+      touchstone = touchstone,
+      scenarios = c("mena-no-vaccination", "mena-campaign-default",
+                    "mena-routine-default", "mena-booster-default",
+                    "mena-campaign-ia2030_target", "mena-routine-ia2030_target"),
+      in_path = file.path(in_path, "Cambridge-Trotter"),
+      files = c(paste0(stub, "no_vaccination_:index.csv.xz"),
+                paste0(stub, "campaign_default_:index.csv.xz"),
+                paste0(stub, "routine_default_:index.csv.xz"),
+                paste0(stub, "booster_:index.csv.xz"),
+                paste0(stub, "campaign-ia2030_target_:index.csv.xz"),
+                paste0(stub, "routine-ia2030_target_:index.csv.xz")),
+      cert = "",
+      index_start = 1,
+      index_end = 26,
+      out_path = out_path,
+      pre_aggregation_path = pre_aggregation_path,
+      log_file = log_file,
+      bypass_cert_check = TRUE,
+      lines = lines)
+    files <- data.frame(
+      touchstone = touchstone,
+      modelling_group = modelling_group,
+      disease = disease,
+      files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
+                paths$all_cal_file, paths$all_coh_file),
+      is_cohort = c(FALSE, TRUE, FALSE, TRUE),
+      is_under5 = c(TRUE, TRUE, FALSE, FALSE)
+    )
+  })
+  write.table(files, output_files, sep = ",", append = TRUE,
+              row.names = FALSE, col.names = FALSE)
 
   #############################################################################
 

--- a/scripts/run_stochastic_process.R
+++ b/scripts/run_stochastic_process.R
@@ -20,12 +20,11 @@ continue_on_error <- function(expr) {
 }
 
 
-do_stochastics_2021 <- function(con, test_run) {
-  in_path <- "Z:/File requests/latest/202110gavi/"
-  out_path <- "Z:/stochastic_2021_output/aggregated/"
-  pre_aggregation_path <- "Z:/stochastic_2021_output/pre-aggregate/"
-  log_file <- "Z:/stochastic_2021_output/log.txt"
-  output_files <- "Z:/stochastic_2021_output/output_files.csv"
+do_stochastics_2021 <- function(con, test_run, in_path, out_path) {
+  aggregated_path <- file.path(out_path, "aggregated")
+  pre_aggregation_path <- file.path(out_path, "pre-aggregate")
+  log_file <- file.path(out_path, "log.txt")
+  output_files <- file.path(out_path, "output_files.csv")
   files <- data.frame(
     touchstone = character(0),
     modelling_group = character(0),
@@ -34,7 +33,7 @@ do_stochastics_2021 <- function(con, test_run) {
     is_cohort = logical(0),
     is_under5 = logical(0)
   )
-  dir.create(out_path, showWarnings = FALSE, recursive = TRUE)
+  dir.create(aggregated_path, showWarnings = FALSE, recursive = TRUE)
   dir.create(pre_aggregation_path, showWarnings = FALSE, recursive = TRUE)
   write.csv(files, output_files, row.names = FALSE)
 
@@ -66,7 +65,7 @@ do_stochastics_2021 <- function(con, test_run) {
       cert = "",
       index_start = 1,
       index_end = 26,
-      out_path = out_path,
+      out_path = aggregated_path,
       pre_aggregation_path = pre_aggregation_path,
       log_file = log_file,
       bypass_cert_check = TRUE,
@@ -106,7 +105,7 @@ do_stochastics_2021 <- function(con, test_run) {
       cert = "",
       index_start = NA,
       index_end = NA,
-      out_path = out_path,
+      out_path = aggregated_path,
       pre_aggregation_path = pre_aggregation_path,
       log_file = log_file,
       allow_missing_disease = TRUE,
@@ -151,7 +150,7 @@ do_stochastics_2021 <- function(con, test_run) {
       cert = "",
       index_start = 1,
       index_end = 200,
-      out_path = out_path,
+      out_path = aggregated_path,
       pre_aggregation_path = pre_aggregation_path,
       log_file = log_file,
       runid_from_file = TRUE,
@@ -192,7 +191,7 @@ do_stochastics_2021 <- function(con, test_run) {
       cert = "",
       index_start = 1,
       index_end = 200,
-      out_path = out_path,
+      out_path = aggregated_path,
       pre_aggregation_path = pre_aggregation_path,
       log_file = log_file,
       bypass_cert_check = TRUE,
@@ -233,7 +232,7 @@ do_stochastics_2021 <- function(con, test_run) {
       cert = "",
       index_start = NA,
       index_end = NA,
-      out_path = out_path,
+      out_path = aggregated_path,
       pre_aggregation_path = pre_aggregation_path,
       log_file = log_file,
       bypass_cert_check = TRUE,
@@ -275,7 +274,7 @@ do_stochastics_2021 <- function(con, test_run) {
       cert = "Margaret de Villiers - cert115",
       index_start = 1,
       index_end = 200,
-      out_path = out_path,
+      out_path = aggregated_path,
       pre_aggregation_path = pre_aggregation_path,
       log_file = log_file,
       deaths = "deaths",
@@ -314,7 +313,7 @@ do_stochastics_2021 <- function(con, test_run) {
       cert = "",
       index_start = NA,
       index_end = NA,
-      out_path = out_path,
+      out_path = aggregated_path,
       pre_aggregation_path = pre_aggregation_path,
       log_file = log_file,
       bypass_cert_check = TRUE,
@@ -350,7 +349,7 @@ do_stochastics_2021 <- function(con, test_run) {
       cert = "",
       index_start = NA,
       index_end = NA,
-      out_path = out_path,
+      out_path = aggregated_path,
       pre_aggregation_path = pre_aggregation_path,
       log_file = log_file,
       bypass_cert_check = TRUE,
@@ -403,7 +402,7 @@ do_stochastics_2021 <- function(con, test_run) {
       cert = "",
       index_start = 1,
       index_end = 11,
-      out_path = out_path,
+      out_path = aggregated_path,
       pre_aggregation_path = pre_aggregation_path,
       log_file = log_file,
       deaths = "rubella_deaths_congenital",
@@ -453,7 +452,7 @@ do_stochastics_2021 <- function(con, test_run) {
       cert = "",
       index_start = NA,
       index_end = NA,
-      out_path = out_path,
+      out_path = aggregated_path,
       pre_aggregation_path = pre_aggregation_path,
       log_file = log_file,
       deaths = c("deaths_men", "deaths_pneumo"),
@@ -477,10 +476,11 @@ do_stochastics_2021 <- function(con, test_run) {
   # And to sort out DALYs on the centrals:
 
   for (hib_scenario in hib_scenarios) {
-    stoner::stoner_dalys_for_db(con, list_params_hib_pcv, "JHU-Tam",
-                                "Hib", "202110gavi-3", hib_scenario,
-                                output_file = file.path(out_path, sprintf("%s_central_dalys.qs",
-                                                                          hib_scenario)))
+    stoner::stoner_dalys_for_db(
+      con, list_params_hib_pcv, "JHU-Tam",
+      "Hib", "202110gavi-3", hib_scenario,
+      output_file = file.path(aggregated_path,
+                              sprintf("%s_central_dalys.qs", hib_scenario)))
   }
 
   pcv_scenarios <- c("pcv-no-vaccination-LiST",
@@ -502,7 +502,7 @@ do_stochastics_2021 <- function(con, test_run) {
       cert = "",
       index_start = NA,
       index_end = NA,
-      out_path = out_path,
+      out_path = aggregated_path,
       pre_aggregation_path = pre_aggregation_path,
       log_file = log_file,
       deaths = c("deaths_men", "deaths_pneumo"),
@@ -526,10 +526,11 @@ do_stochastics_2021 <- function(con, test_run) {
   # And to sort out DALYs on the centrals:
 
   for (pcv_scenario in pcv_scenarios) {
-    stoner::stoner_dalys_for_db(con, list_params_hib_pcv, "JHU-Tam",
-                                "PCV", "202110gavi-3", pcv_scenario,
-                                output_file = file.path(out_path, sprintf("%s_central_dalys.qs",
-                                                                          pcv_scenario)))
+    stoner::stoner_dalys_for_db(
+      con, list_params_hib_pcv, "JHU-Tam",
+      "PCV", "202110gavi-3", pcv_scenario,
+      output_file = file.path(aggregated_path,
+                              sprintf("%s_central_dalys.qs", pcv_scenario)))
   }
 
 
@@ -559,7 +560,7 @@ do_stochastics_2021 <- function(con, test_run) {
       cert = "",
       index_start = NA,
       index_end = NA,
-      out_path = out_path,
+      out_path = aggregated_path,
       pre_aggregation_path = pre_aggregation_path,
       log_file = log_file,
       dalys = list_params_rota,
@@ -582,10 +583,11 @@ do_stochastics_2021 <- function(con, test_run) {
   # And to sort out DALYs on the centrals:
 
   for (rota_scenario in rota_scenarios) {
-    stoner::stoner_dalys_for_db(con, list_params_rota, "JHU-Tam",
-                                "Rota", "202110gavi-3", rota_scenario,
-                                output_file = file.path(out_path, sprintf("%s_central_dalys.qs",
-                                                                          rota_scenario)))
+    stoner::stoner_dalys_for_db(
+      con, list_params_rota, "JHU-Tam",
+      "Rota", "202110gavi-3", rota_scenario,
+      output_file = file.path(aggregated_path,
+                              sprintf("%s_central_dalys.qs", rota_scenario)))
   }
 
   ####################################################################################
@@ -617,7 +619,7 @@ do_stochastics_2021 <- function(con, test_run) {
       cert = "",
       index_start = 1,
       index_end = 26,
-      out_path = out_path,
+      out_path = aggregated_path,
       pre_aggregation_path = pre_aggregation_path,
       log_file = log_file,
       bypass_cert_check = TRUE,
@@ -659,7 +661,7 @@ do_stochastics_2021 <- function(con, test_run) {
       cert = "cert105",
       index_start = 1,
       index_end = 200,
-      out_path = out_path,
+      out_path = aggregated_path,
       pre_aggregation_path = pre_aggregation_path,
       log_file = log_file,
       deaths = c("hepb_deaths_acute", "hepb_deaths_total_cirrh", "hepb_deaths_hcc"),
@@ -698,7 +700,7 @@ do_stochastics_2021 <- function(con, test_run) {
       cert = "Kaja Abbas - hib_cert116",
       index_start = NA,
       index_end = NA,
-      out_path = out_path,
+      out_path = aggregated_path,
       pre_aggregation_path = pre_aggregation_path,
       log_file = log_file,
       lines = lines)
@@ -734,7 +736,7 @@ do_stochastics_2021 <- function(con, test_run) {
       cert = "Kaja Abbas - rota_cert117",
       index_start = NA,
       index_end = NA,
-      out_path = out_path,
+      out_path = aggregated_path,
       pre_aggregation_path = pre_aggregation_path,
       log_file = log_file,
       lines = lines)
@@ -775,7 +777,10 @@ do_stochastics_2021 <- function(con, test_run) {
                 paste0(stub, "vaccination_all_202110gavi-3_hpv-routine-default.csv.xz"),
                 paste0(stub, "vaccination_all_202110gavi-3_hpv-campaign-ia2030_target.csv.xz"),
                 paste0(stub, "vaccination_all_202110gavi-3_hpv-routine-ia2030_target.csv.xz")),
-      cert = "cert104", index_start = NA, index_end = NA, out_path = out_path,
+      cert = "cert104",
+      index_start = NA,
+      index_end = NA,
+      out_path = aggregated_path,
       pre_aggregation_path = pre_aggregation_path,
       log_file = log_file,
       bypass_cert_check = TRUE,
@@ -827,7 +832,7 @@ do_stochastics_2021 <- function(con, test_run) {
       cert = "Han Fu - cert112_measles-LSHTM-Jit_202110gavi-3",
       index_start = NA,
       index_end = NA,
-      out_path = out_path,
+      out_path = aggregated_path,
       pre_aggregation_path = pre_aggregation_path,
       log_file = log_file,
       lines = lines)
@@ -862,7 +867,7 @@ do_stochastics_2021 <- function(con, test_run) {
       cert = "Jemima Koh - cert121",
       index_start = NA,
       index_end = NA,
-      out_path = out_path,
+      out_path = aggregated_path,
       pre_aggregation_path = pre_aggregation_path,
       log_file = log_file,
       lines = lines)
@@ -912,7 +917,7 @@ do_stochastics_2021 <- function(con, test_run) {
       cert = "",
       index_start = 1,
       index_end = 112,
-      out_path = out_path,
+      out_path = aggregated_path,
       pre_aggregation_path = pre_aggregation_path,
       log_file = log_file,
       deaths = "rubella_deaths_congenital",
@@ -959,7 +964,7 @@ do_stochastics_2021 <- function(con, test_run) {
       cert = "",
       index_start = NA,
       index_end = NA,
-      out_path = out_path,
+      out_path = aggregated_path,
       pre_aggregation_path = pre_aggregation_path,
       log_file = log_file,
       bypass_cert_check = TRUE,
@@ -1000,7 +1005,7 @@ do_stochastics_2021 <- function(con, test_run) {
       cert = "Sean Moore - cert108",
       index_start = NA,
       index_end = NA,
-      out_path = out_path,
+      out_path = aggregated_path,
       pre_aggregation_path = pre_aggregation_path,
       log_file = log_file,
       lines = lines)
@@ -1041,7 +1046,7 @@ do_stochastics_2021 <- function(con, test_run) {
       cert = "",
       index_start = 1,
       index_end = 200,
-      out_path = out_path,
+      out_path = aggregated_path,
       pre_aggregation_path = pre_aggregation_path,
       log_file = log_file,
       bypass_cert_check = TRUE,
@@ -1085,7 +1090,7 @@ do_stochastics_2021 <- function(con, test_run) {
       cert = "",
       index_start = NA,
       index_end = NA,
-      out_path = out_path,
+      out_path = aggregated_path,
       pre_aggregation_path = pre_aggregation_path,
       log_file = log_file,
       bypass_cert_check = TRUE,
@@ -1104,11 +1109,10 @@ do_stochastics_2021 <- function(con, test_run) {
   })
 }
 
-do_stochastics_2019 <- function(con, test_run) {
-  in_path <- "E:/Dropbox (SPH Imperial College)/File requests/latest/201910gavi"
-  out_path <- "E:/stochastic_2019_output/aggregated/"
-  pre_aggregation_path <- "E:/stochastic_2019_output/pre-aggregate/"
-  log_file <- "E:/stochsatic_2019_output/log.txt"
+do_stochastics_2019 <- function(con, test_run, in_path, out_path) {
+  aggregation_path <- file.path(out_path, "aggregated")
+  pre_aggregation_path <- file.path(out_path, "pre-aggregate")
+  log_file <- file.path(out_path, "log.txt")
 
   lines <- Inf
   if (isTRUE(test_run)) {
@@ -1134,7 +1138,7 @@ do_stochastics_2019 <- function(con, test_run) {
     cert = "cert60",
     index_start = 1,
     index_end = 52,
-    out_path = out_path,
+    out_path = aggregated_path,
     pre_aggregation_path = pre_aggregation_path,
     log_file = log_file,
     lines = lines))
@@ -1168,7 +1172,7 @@ do_stochastics_2019 <- function(con, test_run) {
     cert = "Ivane Gamkrelidze - cert68",
     index_start = NA,
     index_end = NA,
-    out_path = out_path,
+    out_path = aggregated_path,
     pre_aggregation_path = pre_aggregation_path,
     log_file = log_file,
     deaths = c("hepb_deaths_acute","hepb_deaths_dec_cirrh","hepb_deaths_hcc"),
@@ -1192,7 +1196,7 @@ do_stochastics_2019 <- function(con, test_run) {
     cert = "Molly Steele - cert66",
     index_start = NA,
     index_end = NA,
-    out_path= out_path,
+    out_path= aggregated_path,
     pre_aggregation_path = pre_aggregation_path,
     log_file = log_file,
     allow_missing_disease = TRUE,
@@ -1220,7 +1224,7 @@ do_stochastics_2019 <- function(con, test_run) {
     cert = "",
     index_start = 1,
     index_end = 200,
-    out_path = out_path,
+    out_path = aggregated_path,
     pre_aggregation_path = pre_aggregation_path,
     log_file = log_file,
     runid_from_file = TRUE,
@@ -1246,7 +1250,7 @@ do_stochastics_2019 <- function(con, test_run) {
     cert = "Katy Gaythorpe - cert62",
     index_start = 1,
     index_end = 200,
-    out_path = out_path,
+    out_path = aggregated_path,
     pre_aggregation_path = pre_aggregation_path,
     log_file = log_file,
     lines = lines))
@@ -1272,7 +1276,7 @@ do_stochastics_2019 <- function(con, test_run) {
     cert = "Margaret de Villiers  - cert73",
     index_start = 1,
     index_end = 200,
-    out_path = out_path,
+    out_path = aggregated_path,
     pre_aggregation_path = pre_aggregation_path,
     log_file = log_file,
     deaths = "deaths",
@@ -1295,7 +1299,7 @@ do_stochastics_2019 <- function(con, test_run) {
     cert = "Jong-Hoon Kim - cert89",
     index_start = NA,
     index_end = NA,
-    out_path = out_path,
+    out_path = aggregated_path,
     pre_aggregation_path = pre_aggregation_path,
     log_file = log_file,
     lines = lines))
@@ -1315,7 +1319,7 @@ do_stochastics_2019 <- function(con, test_run) {
     cert = "Jong-Hoon Kim - cert90",
     index_start = NA,
     index_end = NA,
-    out_path = out_path,
+    out_path = aggregated_path,
     pre_aggregation_path = pre_aggregation_path,
     log_file = log_file,
     lines = lines))
@@ -1343,7 +1347,7 @@ do_stochastics_2019 <- function(con, test_run) {
               paste0(stub, "rubella-no-vaccination_:index.csv.xz"),
               rep(paste0(stub, ":scenario_:index.csv.xz"), 7)),
     cert = "Amy Winter - cert70",
-    index_start = 1, index_end = 12, out_path = out_path,
+    index_start = 1, index_end = 12, out_path = aggregated_path,
     pre_aggregation_path = pre_aggregation_path,
     log_file = log_file,
     deaths = "rubella_deaths_congenital",
@@ -1373,7 +1377,7 @@ do_stochastics_2019 <- function(con, test_run) {
     cert = "cert61",
     index_start = 1,
     index_end = 26,
-    out_path = out_path,
+    out_path = aggregated_path,
     lines = lines))
 
   #############################################################################
@@ -1390,7 +1394,7 @@ do_stochastics_2019 <- function(con, test_run) {
     cert = "",
     index_start = NA,
     index_end = NA,
-    out_path = out_path,
+    out_path = aggregated_path,
     pre_aggregation_path = pre_aggregation_path,
     log_file = log_file,
     bypass_cert_check = TRUE,
@@ -1417,7 +1421,7 @@ do_stochastics_2019 <- function(con, test_run) {
     cert = "",
     index_start = 1,
     index_end = 14,
-    out_path = out_path,
+    out_path = aggregated_path,
     deaths = c("deaths_men", "deaths_pneumo"),
     cases = c("cases_men", "cases_pneumo"),
     dalys = list_params_hib_pcv,
@@ -1437,7 +1441,7 @@ do_stochastics_2019 <- function(con, test_run) {
     cert = "",
     index_start = 1,
     index_end = 14,
-    out_path = out_path,
+    out_path = aggregated_path,
     pre_aggregation_path = pre_aggregation_path,
     log_file = log_file,
     deaths = c("deaths_men", "deaths_pneumo"),
@@ -1464,7 +1468,7 @@ do_stochastics_2019 <- function(con, test_run) {
     cert  = "",
     index_start = 1,
     index_end = 14,
-    out_path = out_path,
+    out_path = aggregated_path,
     pre_aggregation_path = pre_aggregation_path,
     log_file = log_file,
     dalys = list_params_rota,
@@ -1492,7 +1496,7 @@ do_stochastics_2019 <- function(con, test_run) {
     cert = "cert74",
     index_start = 1,
     index_end = 200,
-    out_path = out_path,
+    out_path = aggregated_path,
     pre_aggregation_path = pre_aggregation_path,
     log_file = log_file,
     deaths = c("hepb_deaths_acute", "hepb_deaths_total_cirrh", "hepb_deaths_hcc"),
@@ -1517,7 +1521,7 @@ do_stochastics_2019 <- function(con, test_run) {
     cert = "cert81",
     index_start = NA,
     index_end = NA,
-    out_path = out_path,
+    out_path = aggregated_path,
     pre_aggregation_path = pre_aggregation_path,
     log_file = log_file,
     lines = lines))
@@ -1536,7 +1540,7 @@ do_stochastics_2019 <- function(con, test_run) {
     cert = "cert82",
     index_start = NA,
     index_end = NA,
-    out_path = out_path,
+    out_path = aggregated_path,
     pre_aggregation_path = pre_aggregation_path,
     log_file = log_file,
     lines = lines))
@@ -1555,7 +1559,7 @@ do_stochastics_2019 <- function(con, test_run) {
     cert = "",
     index_start = NA,
     index_end = NA,
-    out_path = out_path,
+    out_path = aggregated_path,
     pre_aggregation_path = pre_aggregation_path,
     log_file = log_file,
     lines = lines))
@@ -1582,7 +1586,7 @@ do_stochastics_2019 <- function(con, test_run) {
     cert = "Kaja Abbas - stochastic_parameters_certificate_HPV_LSHTM-Jit_201910gavi-4",
     index_start = NA,
     index_end = NA,
-    out_path = out_path,
+    out_path = aggregated_path,
     pre_aggregation_path = pre_aggregation_path,
     log_file = log_file,
     bypass_cert_check = TRUE,
@@ -1612,7 +1616,7 @@ do_stochastics_2019 <- function(con, test_run) {
     cert = "cert83",
     index_start = NA,
     index_end = NA,
-    out_path = out_path,
+    out_path = aggregated_path,
     pre_aggregation_path = pre_aggregation_path,
     log_file = log_file,
     lines = lines))
@@ -1639,7 +1643,7 @@ do_stochastics_2019 <- function(con, test_run) {
     cert = "cert76",
     index_start = 1,
     index_end = 200,
-    out_path = out_path,
+    out_path = aggregated_path,
     pre_aggregation_path = pre_aggregation_path,
     log_file = log_file,
     lines = lines))
@@ -1666,7 +1670,7 @@ do_stochastics_2019 <- function(con, test_run) {
     files = paste0(stub, ":scenario_country:index.csv.xz"),
     cert = "", index_start = 1,
     index_end = 112,
-    out_path = out_path,
+    out_path = aggregated_path,
     pre_aggregation_path = pre_aggregation_path,
     log_file = log_file,
     deaths = "rubella_deaths_congenital",
@@ -1706,7 +1710,7 @@ do_stochastics_2019 <- function(con, test_run) {
     cert = "Heather Santos - cert80",
     index_start = 1,
     index_end = 8,
-    out_path = out_path,
+    out_path = aggregated_path,
     pre_aggregation_path = pre_aggregation_path,
     log_file = log_file,
     lines = lines))
@@ -1733,7 +1737,7 @@ do_stochastics_2019 <- function(con, test_run) {
     cert = "Sean Moore - cert58",
     index_start = NA,
     index_end = NA,
-    out_path = out_path,
+    out_path = aggregated_path,
     pre_aggregation_path = pre_aggregation_path,
     log_file = log_file,
     lines = lines))
@@ -1757,7 +1761,7 @@ do_stochastics_2019 <- function(con, test_run) {
     cert = "John Huber - cert85",
     index_start = 1,
     index_end = 200,
-    out_path = out_path,
+    out_path = aggregated_path,
     pre_aggregation_path = pre_aggregation_path,
     log_file = log_file,
     lines = lines))
@@ -1777,7 +1781,7 @@ do_stochastics_2019 <- function(con, test_run) {
     cert = "Virginia Pitzer - cert88",
     index_start = NA,
     index_end = NA,
-    out_path = out_path,
+    out_path = aggregated_path,
     pre_aggregation_path = pre_aggregation_path,
     log_file = log_file,
     lines = lines))
@@ -1788,5 +1792,10 @@ library(stoner)
 dettl_root <- "~/projects/montagu-imports/"
 con <- dettl:::db_connect("production", dettl_root)
 
-do_stochastics_2021(con, test_run = TRUE)
+in_path <- "Z:/File requests/latest/202110gavi/"
+out_path <- "Z:/stochastic_2021_output/"
+
+do_stochastics_2021(con, test_run = TRUE,
+                    in_path = in_path,
+                    out_path = out_path)
 

--- a/scripts/run_stochastic_process.R
+++ b/scripts/run_stochastic_process.R
@@ -133,7 +133,7 @@ do_stochastics_2021 <- function(con, test_run) {
                   "hpv-campaign-ia2030_target",
                   "hpv-routine-default",
                   "hpv-routine-ia2030_target"),
-    in_path = in_path,
+    in_path = file.path(in_path, "Harvard-Sweet"),
     files = c(paste0(stub, "novacc_run_:index.csv.xz"),
               paste0(stub, "coverage_202110gavi-3_hpv-campaign-default_run_:index.csv.xz"),
               paste0(stub, "coverage_202110gavi-3_hpv-campaign-ia2030_target_run_:index.csv.xz"),
@@ -175,7 +175,7 @@ do_stochastics_2021 <- function(con, test_run) {
                   "yf-preventive-ia2030_target",
                   "yf-routine-default",
                   "yf-routine-ia2030_target"),
-    in_path = file.path(in_path, "IC-Garske-YF"),
+    in_path = file.path(in_path, "IC-Garske"),
     files = paste0(stub, ":scenario_:index.csv.xz"),
     cert = "",
     index_start = 1,
@@ -209,7 +209,7 @@ do_stochastics_2021 <- function(con, test_run) {
     scenarios = c("typhoid-no-vaccination",
                   "typhoid-campaign-default", "typhoid-campaign-ia2030_target",
                   "typhoid-routine-default",  "typhoid-routine-ia2030_target"),
-    in_path = in_path,
+    in_path = file.path(in_path, "IVI-Kim-Typhoid"),
     files = c("Jong-Hoon Kim - stoch_Typhoid_novacc_20211217T1.csv.xz",
               "Jong-Hoon Kim - stoch_Typhoid_campaign-default_20211217T1.csv.xz",
               "Jong-Hoon Kim - stoch_Typhoid_campaign-ia2030_20211217T1.csv.xz",
@@ -252,7 +252,7 @@ do_stochastics_2021 <- function(con, test_run) {
                   "hepb-hepb-routine-default",
                   "hepb-hepb-routine-ia2030_target",
                   "hepb-no-vaccination"),
-    in_path = in_path,
+    in_path = file.path(in_path, "IC-Hallett"),
     files = paste0(stub, ":scenario_:index.csv.xz"),
     cert = "Margaret de Villiers - cert115",
     index_start = 1,
@@ -363,7 +363,7 @@ do_stochastics_2021 <- function(con, test_run) {
                   "rubella-rcv1-ia2030_target",
                   "rubella-rcv2-ia2030_target",
                   "rubella-rcv1-rcv2-ia2030_target"),
-    in_path = in_path,
+    in_path = file.path(in_path, "JHU-UGA-Winter-Rubella"),
     files = c(paste0(stub, "routine-no-vaccination_:index.csv.xz"),
               paste0(stub, "campaign-default_:index.csv.xz"),
               paste0(stub, "rcv1-default_:index.csv.xz"),
@@ -418,7 +418,7 @@ do_stochastics_2021 <- function(con, test_run) {
     disease = disease,
     touchstone = touchstone,
     scenarios = hib_scenarios,
-    in_path = file.path(in_path),
+    in_path = file.path(in_path, "JHU-Tam-Carter-Hib"),
     files = ":scenario.csv.xz",
     cert = "",
     index_start = NA,
@@ -464,7 +464,7 @@ do_stochastics_2021 <- function(con, test_run) {
     disease = disease,
     touchstone = touchstone,
     scenarios = pcv_scenarios,
-    in_path = file.path(in_path),
+    in_path = file.path(in_path, "JHU-Tam-Carter-PCV"),
     files = ":scenario.csv.xz",
     cert = "",
     index_start = NA,
@@ -506,7 +506,6 @@ do_stochastics_2021 <- function(con, test_run) {
   )
 
   rota_scenarios <- c("rota-no-vaccination-LiST",
-                      "rota-routine-default-LiST",
                       "rota-routine-ia2030_target-LiST")
 
   modelling_group = "JHU-Tam"
@@ -518,7 +517,7 @@ do_stochastics_2021 <- function(con, test_run) {
     disease = disease,
     touchstone = touchstone,
     scenarios = rota_scenarios,
-    in_path = file.path(in_path),
+    in_path = file.path(in_path, "JHU-Tam-Carter-Rota"),
     files = ":scenario.csv.xz",
     cert = "",
     index_start = NA,
@@ -552,7 +551,8 @@ do_stochastics_2021 <- function(con, test_run) {
 
   ####################################################################################
 
-  stub <- "Eric Johnson - "
+
+  stub <- "stochastic_burden_est_MenA_KPWA_"
   modelling_group = "KPW-Jackson"
   disease = "MenA"
   touchstone = "202110gavi-3"
@@ -568,10 +568,15 @@ do_stochastics_2021 <- function(con, test_run) {
                   "mena-routine-default",
                   "mena-routine-ia2030_target"),
     in_path = file.path(in_path, "KPW-Jackson-MenA"),
-    files = paste0(stub, ":scenario-202111gavi-2.MenA_KPW-Johnson.csv.xz"),
+    files = c(paste0(stub, "booster_default_:index.csv.xz"),
+              paste0(stub, "campaign_default_:index.csv.xz"),
+              paste0(stub, "campaign_ia2030_target_:index.csv.xz"),
+              paste0(stub, "none_default_:index.csv.xz"),
+              paste0(stub, "routine_default_:index.csv.xz"),
+              paste0(stub, "routine_ia2030_target_:index.csv.xz")),
     cert = "",
-    index_start = NA,
-    index_end = NA,
+    index_start = 1,
+    index_end = 26,
     out_path = out_path,
     pre_aggregation_path = pre_aggregation_path,
     log_file = log_file,
@@ -607,7 +612,7 @@ do_stochastics_2021 <- function(con, test_run) {
                   "hepb-no-vaccination"
     ),
     in_path = file.path(in_path, "Li"),
-    files = paste0(":scenario:index.csv"),
+    files = paste0(":scenario:index.csv.xz"),
     cert = "cert105",
     index_start = 1,
     index_end = 200,
@@ -712,7 +717,7 @@ do_stochastics_2021 <- function(con, test_run) {
                   "hpv-routine-default",
                   "hpv-campaign-ia2030_target",
                   "hpv-routine-ia2030_target"),
-    in_path = "E:/Dropbox (SPH Imperial College)/File requests/latest/202110gavi/LSHTM-Jit_HPV",
+    in_path = file.path(in_path, "LSHTM-Jit_HPV"),
     files = c(paste0(stub, "novaccination_all_202110gavi-3_hpv-no-vaccination.csv.xz"),
               paste0(stub, "vaccination_all_202110gavi-3_hpv-campaign-default.csv.xz"),
               paste0(stub, "vaccination_all_202110gavi-3_hpv-routine-default.csv.xz"),
@@ -739,7 +744,7 @@ do_stochastics_2021 <- function(con, test_run) {
   stub <- "Han Fu - stochastic_burden_estimate_measles-LSHTM-Jit-"
   modelling_group = "LSHTM-Jit"
   disease = "Measles"
-  touchstone = "202110gavi-2"
+  touchstone = "202110gavi-3"
   continue_on_error(paths <- stone_stochastic_process(
     con,
     modelling_group = modelling_group,
@@ -764,7 +769,7 @@ do_stochastics_2021 <- function(con, test_run) {
               paste0(stub, "campaign-only-ia2030_target.csv.xz"),
               paste0(stub, "mcv1-ia2030_target.csv.xz"),
               paste0(stub, "mcv2-ia2030_target.csv.xz")),
-    cert = "Han Fu - cert107",
+    cert = "Han Fu - cert112_measles-LSHTM-Jit_202110gavi-3",
     index_start = NA,
     index_end = NA,
     out_path = out_path,
@@ -864,6 +869,37 @@ do_stochastics_2021 <- function(con, test_run) {
     is_under5 = c(TRUE, TRUE, FALSE, FALSE)
   )
   write.csv(files, output_files, append = TRUE, row.names = FALSE)
+
+  #############################################################################
+
+  stub <- "coverage_202110gavi-3_"
+  modelling_group = "PSU-Ferrari"
+  disease = "Measles"
+  touchstone = "202110gavi-3"
+  continue_on_error(paths <- stone_stochastic_process(
+    con,
+    modelling_group = modelling_group,
+    disease = disease,
+    touchstone = touchstone,
+    scenarios = c("measles-campaign-default",
+                  "measles-campaign-ia2030_target",
+                  "measles-campaign-only-default",
+                  "measles-campaign-only-ia2030_target",
+                  "measles-mcv1-default",
+                  "measles-mcv1-ia2030_target",
+                  "measles-mcv2-default",
+                  "measles-mcv2-ia2030_target",
+                  "measles-no-vaccination"),
+    in_path = file.path(in_path, "PSU-Ferrari-Measles"),
+    files = paste0(stub, ":scenario.csv.xz"),
+    cert = "",
+    index_start = NA,
+    index_end = NA,
+    out_path = out_path,
+    pre_aggregation_path = pre_aggregation_path,
+    log_file = log_file,
+    bypass_cert_check = TRUE,
+    lines = lines))
 
   #############################################################################
 
@@ -1193,7 +1229,8 @@ do_stochastics_2019 <- function(con, test_run) {
               "Jong-Hoon Kim - stoch_Typhoid_routine.csv.xz"),
     cert = "Jong-Hoon Kim - cert90",
     index_start = NA,
-    index_end = NA, out_path = out_path,
+    index_end = NA,
+    out_path = out_path,
     pre_aggregation_path = pre_aggregation_path,
     log_file = log_file,
     lines = lines))

--- a/scripts/run_stochastic_process.R
+++ b/scripts/run_stochastic_process.R
@@ -19,6 +19,20 @@ continue_on_error <- function(expr) {
   )
 }
 
+write_output_metadata <- function(touchstone, modelling_group, disease,
+                                  paths, metadata_csv) {
+  files <- data.frame(
+    touchstone = touchstone,
+    modelling_group = modelling_group,
+    disease = disease,
+    files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
+              paths$all_cal_file, paths$all_coh_file),
+    is_cohort = c(FALSE, TRUE, FALSE, TRUE),
+    is_under5 = c(TRUE, TRUE, FALSE, FALSE)
+  )
+  write.table(files, output_files, sep = ",", append = TRUE,
+              row.names = FALSE, col.names = FALSE)
+}
 
 do_stochastics_2021 <- function(con, test_run, in_path, out_path) {
   aggregated_path <- file.path(out_path, "aggregated")
@@ -70,17 +84,9 @@ do_stochastics_2021 <- function(con, test_run, in_path, out_path) {
       log_file = log_file,
       bypass_cert_check = TRUE,
       lines = lines)
-    files <- data.frame(
-      touchstone = touchstone,
-      modelling_group = modelling_group,
-      disease = disease,
-      files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
-                paths$all_cal_file, paths$all_coh_file),
-      is_cohort = c(FALSE, TRUE, FALSE, TRUE),
-      is_under5 = c(TRUE, TRUE, FALSE, FALSE)
-    )
-    write.table(files, output_files, sep = ",", append = TRUE,
-                row.names = FALSE, col.names = FALSE)
+
+    write_output_metadata(touchstone, modelling_group, disease,
+                          paths, output_files)
   })
 
   #############################################################################
@@ -111,17 +117,8 @@ do_stochastics_2021 <- function(con, test_run, in_path, out_path) {
       allow_missing_disease = TRUE,
       bypass_cert_check = TRUE,
       lines = lines)
-    files <- data.frame(
-      touchstone = touchstone,
-      modelling_group = modelling_group,
-      disease = disease,
-      files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
-                paths$all_cal_file, paths$all_coh_file),
-      is_cohort = c(FALSE, TRUE, FALSE, TRUE),
-      is_under5 = c(TRUE, TRUE, FALSE, FALSE)
-    )
-    write.table(files, output_files, sep = ",", append = TRUE,
-                row.names = FALSE, col.names = FALSE)
+    write_output_metadata(touchstone, modelling_group, disease,
+                          paths, output_files)
   })
 
   #############################################################################
@@ -156,17 +153,8 @@ do_stochastics_2021 <- function(con, test_run, in_path, out_path) {
       runid_from_file = TRUE,
       bypass_cert_check = TRUE,
       lines = lines)
-    files <- data.frame(
-      touchstone = touchstone,
-      modelling_group = modelling_group,
-      disease = disease,
-      files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
-                paths$all_cal_file, paths$all_coh_file),
-      is_cohort = c(FALSE, TRUE, FALSE, TRUE),
-      is_under5 = c(TRUE, TRUE, FALSE, FALSE)
-    )
-    write.table(files, output_files, sep = ",", append = TRUE,
-                row.names = FALSE, col.names = FALSE)
+    write_output_metadata(touchstone, modelling_group, disease,
+                          paths, output_files)
   })
 
   #############################################################################
@@ -196,17 +184,8 @@ do_stochastics_2021 <- function(con, test_run, in_path, out_path) {
       log_file = log_file,
       bypass_cert_check = TRUE,
       lines = lines)
-    files <- data.frame(
-      touchstone = touchstone,
-      modelling_group = modelling_group,
-      disease = disease,
-      files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
-                paths$all_cal_file, paths$all_coh_file),
-      is_cohort = c(FALSE, TRUE, FALSE, TRUE),
-      is_under5 = c(TRUE, TRUE, FALSE, FALSE)
-    )
-    write.table(files, output_files, sep = ",", append = TRUE,
-                row.names = FALSE, col.names = FALSE)
+    write_output_metadata(touchstone, modelling_group, disease,
+                          paths, output_files)
   })
 
   #############################################################################
@@ -237,17 +216,8 @@ do_stochastics_2021 <- function(con, test_run, in_path, out_path) {
       log_file = log_file,
       bypass_cert_check = TRUE,
       lines = lines)
-    files <- data.frame(
-      touchstone = touchstone,
-      modelling_group = modelling_group,
-      disease = disease,
-      files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
-                paths$all_cal_file, paths$all_coh_file),
-      is_cohort = c(FALSE, TRUE, FALSE, TRUE),
-      is_under5 = c(TRUE, TRUE, FALSE, FALSE)
-    )
-    write.table(files, output_files, sep = ",", append = TRUE,
-                row.names = FALSE, col.names = FALSE)
+    write_output_metadata(touchstone, modelling_group, disease,
+                          paths, output_files)
   })
 
   #####################################################
@@ -282,17 +252,8 @@ do_stochastics_2021 <- function(con, test_run, in_path, out_path) {
                 "hepb_cases_hcc_no_cirrh"),
       dalys = "dalys",
       lines = lines)
-    files <- data.frame(
-      touchstone = touchstone,
-      modelling_group = modelling_group,
-      disease = disease,
-      files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
-                paths$all_cal_file, paths$all_coh_file),
-      is_cohort = c(FALSE, TRUE, FALSE, TRUE),
-      is_under5 = c(TRUE, TRUE, FALSE, FALSE)
-    )
-    write.table(files, output_files, sep = ",", append = TRUE,
-                row.names = FALSE, col.names = FALSE)
+    write_output_metadata(touchstone, modelling_group, disease,
+                          paths, output_files)
   })
 
   #############################################################################
@@ -318,17 +279,8 @@ do_stochastics_2021 <- function(con, test_run, in_path, out_path) {
       log_file = log_file,
       bypass_cert_check = TRUE,
       lines = lines)
-    files <- data.frame(
-      touchstone = touchstone,
-      modelling_group = modelling_group,
-      disease = disease,
-      files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
-                paths$all_cal_file, paths$all_coh_file),
-      is_cohort = c(FALSE, TRUE, FALSE, TRUE),
-      is_under5 = c(TRUE, TRUE, FALSE, FALSE)
-    )
-    write.table(files, output_files, sep = ",", append = TRUE,
-                row.names = FALSE, col.names = FALSE)
+    write_output_metadata(touchstone, modelling_group, disease,
+                          paths, output_files)
   })
 
   #############################################################################
@@ -354,17 +306,8 @@ do_stochastics_2021 <- function(con, test_run, in_path, out_path) {
       log_file = log_file,
       bypass_cert_check = TRUE,
       lines = lines)
-    files <- data.frame(
-      touchstone = touchstone,
-      modelling_group = modelling_group,
-      disease = disease,
-      files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
-                paths$all_cal_file, paths$all_coh_file),
-      is_cohort = c(FALSE, TRUE, FALSE, TRUE),
-      is_under5 = c(TRUE, TRUE, FALSE, FALSE)
-    )
-    write.table(files, output_files, sep = ",", append = TRUE,
-                row.names = FALSE, col.names = FALSE)
+    write_output_metadata(touchstone, modelling_group, disease,
+                          paths, output_files)
   })
 
   #############################################################################
@@ -410,17 +353,8 @@ do_stochastics_2021 <- function(con, test_run, in_path, out_path) {
       dalys = "dalys",
       bypass_cert_check = TRUE,
       lines = lines)
-    files <- data.frame(
-      touchstone = touchstone,
-      modelling_group = modelling_group,
-      disease = disease,
-      files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
-                paths$all_cal_file, paths$all_coh_file),
-      is_cohort = c(FALSE, TRUE, FALSE, TRUE),
-      is_under5 = c(TRUE, TRUE, FALSE, FALSE)
-    )
-    write.table(files, output_files, sep = ",", append = TRUE,
-                row.names = FALSE, col.names = FALSE)
+    write_output_metadata(touchstone, modelling_group, disease,
+                          paths, output_files)
   })
 
   #############################################################################
@@ -460,17 +394,8 @@ do_stochastics_2021 <- function(con, test_run, in_path, out_path) {
       dalys = list_params_hib_pcv,
       bypass_cert_check = TRUE,
       lines = lines)
-    files <- data.frame(
-      touchstone = touchstone,
-      modelling_group = modelling_group,
-      disease = disease,
-      files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
-                paths$all_cal_file, paths$all_coh_file),
-      is_cohort = c(FALSE, TRUE, FALSE, TRUE),
-      is_under5 = c(TRUE, TRUE, FALSE, FALSE)
-    )
-    write.table(files, output_files, sep = ",", append = TRUE,
-                row.names = FALSE, col.names = FALSE)
+    write_output_metadata(touchstone, modelling_group, disease,
+                          paths, output_files)
   })
 
   # And to sort out DALYs on the centrals:
@@ -510,17 +435,8 @@ do_stochastics_2021 <- function(con, test_run, in_path, out_path) {
       dalys = list_params_hib_pcv,
       bypass_cert_check = TRUE,
       lines = lines)
-    files <- data.frame(
-      touchstone = touchstone,
-      modelling_group = modelling_group,
-      disease = disease,
-      files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
-                paths$all_cal_file, paths$all_coh_file),
-      is_cohort = c(FALSE, TRUE, FALSE, TRUE),
-      is_under5 = c(TRUE, TRUE, FALSE, FALSE)
-    )
-    write.table(files, output_files, sep = ",", append = TRUE,
-                row.names = FALSE, col.names = FALSE)
+    write_output_metadata(touchstone, modelling_group, disease,
+                          paths, output_files)
   })
 
   # And to sort out DALYs on the centrals:
@@ -566,17 +482,8 @@ do_stochastics_2021 <- function(con, test_run, in_path, out_path) {
       dalys = list_params_rota,
       bypass_cert_check = TRUE,
       lines = lines)
-    files <- data.frame(
-      touchstone = touchstone,
-      modelling_group = modelling_group,
-      disease = disease,
-      files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
-                paths$all_cal_file, paths$all_coh_file),
-      is_cohort = c(FALSE, TRUE, FALSE, TRUE),
-      is_under5 = c(TRUE, TRUE, FALSE, FALSE)
-    )
-    write.table(files, output_files, sep = ",", append = TRUE,
-                row.names = FALSE, col.names = FALSE)
+    write_output_metadata(touchstone, modelling_group, disease,
+                          paths, output_files)
   })
 
 
@@ -624,17 +531,8 @@ do_stochastics_2021 <- function(con, test_run, in_path, out_path) {
       log_file = log_file,
       bypass_cert_check = TRUE,
       lines = lines)
-    files <- data.frame(
-      touchstone = touchstone,
-      modelling_group = modelling_group,
-      disease = disease,
-      files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
-                paths$all_cal_file, paths$all_coh_file),
-      is_cohort = c(FALSE, TRUE, FALSE, TRUE),
-      is_under5 = c(TRUE, TRUE, FALSE, FALSE)
-    )
-    write.table(files, output_files, sep = ",", append = TRUE,
-                row.names = FALSE, col.names = FALSE)
+    write_output_metadata(touchstone, modelling_group, disease,
+                          paths, output_files)
   })
 
   #############################################################################
@@ -669,17 +567,8 @@ do_stochastics_2021 <- function(con, test_run, in_path, out_path) {
                 "hepb_cases_chronic", "hepb_chronic_symptomatic_in_acute_phase"),
       dalys = "dalys",
       lines = lines)
-    files <- data.frame(
-      touchstone = touchstone,
-      modelling_group = modelling_group,
-      disease = disease,
-      files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
-                paths$all_cal_file, paths$all_coh_file),
-      is_cohort = c(FALSE, TRUE, FALSE, TRUE),
-      is_under5 = c(TRUE, TRUE, FALSE, FALSE)
-    )
-    write.table(files, output_files, sep = ",", append = TRUE,
-                row.names = FALSE, col.names = FALSE)
+    write_output_metadata(touchstone, modelling_group, disease,
+                          paths, output_files)
   })
 
   #############################################################################
@@ -704,17 +593,8 @@ do_stochastics_2021 <- function(con, test_run, in_path, out_path) {
       pre_aggregation_path = pre_aggregation_path,
       log_file = log_file,
       lines = lines)
-    files <- data.frame(
-      touchstone = touchstone,
-      modelling_group = modelling_group,
-      disease = disease,
-      files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
-                paths$all_cal_file, paths$all_coh_file),
-      is_cohort = c(FALSE, TRUE, FALSE, TRUE),
-      is_under5 = c(TRUE, TRUE, FALSE, FALSE)
-    )
-    write.table(files, output_files, sep = ",", append = TRUE,
-                row.names = FALSE, col.names = FALSE)
+    write_output_metadata(touchstone, modelling_group, disease,
+                          paths, output_files)
   })
 
   #############################################################################
@@ -740,17 +620,8 @@ do_stochastics_2021 <- function(con, test_run, in_path, out_path) {
       pre_aggregation_path = pre_aggregation_path,
       log_file = log_file,
       lines = lines)
-    files <- data.frame(
-      touchstone = touchstone,
-      modelling_group = modelling_group,
-      disease = disease,
-      files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
-                paths$all_cal_file, paths$all_coh_file),
-      is_cohort = c(FALSE, TRUE, FALSE, TRUE),
-      is_under5 = c(TRUE, TRUE, FALSE, FALSE)
-    )
-    write.table(files, output_files, sep = ",", append = TRUE,
-                row.names = FALSE, col.names = FALSE)
+    write_output_metadata(touchstone, modelling_group, disease,
+                          paths, output_files)
   })
 
   #############################################################################
@@ -785,17 +656,8 @@ do_stochastics_2021 <- function(con, test_run, in_path, out_path) {
       log_file = log_file,
       bypass_cert_check = TRUE,
       lines = lines)
-    files <- data.frame(
-      touchstone = touchstone,
-      modelling_group = modelling_group,
-      disease = disease,
-      files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
-                paths$all_cal_file, paths$all_coh_file),
-      is_cohort = c(FALSE, TRUE, FALSE, TRUE),
-      is_under5 = c(TRUE, TRUE, FALSE, FALSE)
-    )
-    write.table(files, output_files, sep = ",", append = TRUE,
-                row.names = FALSE, col.names = FALSE)
+    write_output_metadata(touchstone, modelling_group, disease,
+                          paths, output_files)
   })
 
   #############################################################################
@@ -836,17 +698,8 @@ do_stochastics_2021 <- function(con, test_run, in_path, out_path) {
       pre_aggregation_path = pre_aggregation_path,
       log_file = log_file,
       lines = lines)
-    files <- data.frame(
-      touchstone = touchstone,
-      modelling_group = modelling_group,
-      disease = disease,
-      files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
-                paths$all_cal_file, paths$all_coh_file),
-      is_cohort = c(FALSE, TRUE, FALSE, TRUE),
-      is_under5 = c(TRUE, TRUE, FALSE, FALSE)
-    )
-    write.table(files, output_files, sep = ",", append = TRUE,
-                row.names = FALSE, col.names = FALSE)
+    write_output_metadata(touchstone, modelling_group, disease,
+                          paths, output_files)
   })
 
   #############################################################################
@@ -871,17 +724,8 @@ do_stochastics_2021 <- function(con, test_run, in_path, out_path) {
       pre_aggregation_path = pre_aggregation_path,
       log_file = log_file,
       lines = lines)
-    files <- data.frame(
-      touchstone = touchstone,
-      modelling_group = modelling_group,
-      disease = disease,
-      files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
-                paths$all_cal_file, paths$all_coh_file),
-      is_cohort = c(FALSE, TRUE, FALSE, TRUE),
-      is_under5 = c(TRUE, TRUE, FALSE, FALSE)
-    )
-    write.table(files, output_files, sep = ",", append = TRUE,
-                row.names = FALSE, col.names = FALSE)
+    write_output_metadata(touchstone, modelling_group, disease,
+                          paths, output_files)
   })
 
   #############################################################################
@@ -925,17 +769,8 @@ do_stochastics_2021 <- function(con, test_run, in_path, out_path) {
       dalys = "dalys",
       bypass_cert_check = TRUE,
       lines = lines)
-    files <- data.frame(
-      touchstone = touchstone,
-      modelling_group = modelling_group,
-      disease = disease,
-      files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
-                paths$all_cal_file, paths$all_coh_file),
-      is_cohort = c(FALSE, TRUE, FALSE, TRUE),
-      is_under5 = c(TRUE, TRUE, FALSE, FALSE)
-    )
-    write.table(files, output_files, sep = ",", append = TRUE,
-                row.names = FALSE, col.names = FALSE)
+    write_output_metadata(touchstone, modelling_group, disease,
+                          paths, output_files)
   })
 
   #############################################################################
@@ -969,17 +804,8 @@ do_stochastics_2021 <- function(con, test_run, in_path, out_path) {
       log_file = log_file,
       bypass_cert_check = TRUE,
       lines = lines)
-    files <- data.frame(
-      touchstone = touchstone,
-      modelling_group = modelling_group,
-      disease = disease,
-      files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
-                paths$all_cal_file, paths$all_coh_file),
-      is_cohort = c(FALSE, TRUE, FALSE, TRUE),
-      is_under5 = c(TRUE, TRUE, FALSE, FALSE)
-    )
-    write.table(files, output_files, sep = ",", append = TRUE,
-                row.names = FALSE, col.names = FALSE)
+    write_output_metadata(touchstone, modelling_group, disease,
+                          paths, output_files)
   })
 
   #############################################################################
@@ -1009,17 +835,8 @@ do_stochastics_2021 <- function(con, test_run, in_path, out_path) {
       pre_aggregation_path = pre_aggregation_path,
       log_file = log_file,
       lines = lines)
-    files <- data.frame(
-      touchstone = touchstone,
-      modelling_group = modelling_group,
-      disease = disease,
-      files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
-                paths$all_cal_file, paths$all_coh_file),
-      is_cohort = c(FALSE, TRUE, FALSE, TRUE),
-      is_under5 = c(TRUE, TRUE, FALSE, FALSE)
-    )
-    write.table(files, output_files, sep = ",", append = TRUE,
-                row.names = FALSE, col.names = FALSE)
+    write_output_metadata(touchstone, modelling_group, disease,
+                          paths, output_files)
   })
 
 
@@ -1051,17 +868,8 @@ do_stochastics_2021 <- function(con, test_run, in_path, out_path) {
       log_file = log_file,
       bypass_cert_check = TRUE,
       lines = lines)
-    files <- data.frame(
-      touchstone = touchstone,
-      modelling_group = modelling_group,
-      disease = disease,
-      files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
-                paths$all_cal_file, paths$all_coh_file),
-      is_cohort = c(FALSE, TRUE, FALSE, TRUE),
-      is_under5 = c(TRUE, TRUE, FALSE, FALSE)
-    )
-    write.table(files, output_files, sep = ",", append = TRUE,
-                row.names = FALSE, col.names = FALSE)
+    write_output_metadata(touchstone, modelling_group, disease,
+                          paths, output_files)
   })
 
 
@@ -1095,17 +903,8 @@ do_stochastics_2021 <- function(con, test_run, in_path, out_path) {
       log_file = log_file,
       bypass_cert_check = TRUE,
       lines = lines)
-    files <- data.frame(
-      touchstone = touchstone,
-      modelling_group = modelling_group,
-      disease = disease,
-      files = c(paths$all_u5_cal_file, paths$all_u5_coh_file,
-                paths$all_cal_file, paths$all_coh_file),
-      is_cohort = c(FALSE, TRUE, FALSE, TRUE),
-      is_under5 = c(TRUE, TRUE, FALSE, FALSE)
-    )
-    write.table(files, output_files, sep = ",", append = TRUE,
-                row.names = FALSE, col.names = FALSE)
+    write_output_metadata(touchstone, modelling_group, disease,
+                          paths, output_files)
   })
 }
 


### PR DESCRIPTION
This will allow the reading of files in without having to pick out the metadata (touchstone, disease, modelling_group, aggregation) from the filename. It will form the basis for the `touchpoint` table in new schema.

Note that there are some changes here unrelated to saving the output file. Sorry about that, these are changes I made when running the full import but then forgot to push them last time. They are various small fixes to the params needed to successfully run the processing.

I've run this on wpia-didemrc99. You can see the output there